### PR TITLE
switch to using master branch of khmer + sourmash library

### DIFF
--- a/dump_catlas.py
+++ b/dump_catlas.py
@@ -3,7 +3,6 @@
 """
 from __future__ import print_function
 import argparse
-from khmer import MinHash
 from spacegraphcats import graph_parser
 from spacegraphcats.catlas_reader import CAtlasReader
 from spacegraphcats.catlas import CAtlas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 screed
 pytest
 git+https://github.com/dib-lab/khmer.git
-sourmash >= 0.9.4
+sourmash >= 0.9.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 screed
 pytest
-git+https://github.com/dib-lab/khmer.git@minhash
+git+https://github.com/dib-lab/khmer.git
+sourmash >= 0.9.4

--- a/search-catlas-mh.py
+++ b/search-catlas-mh.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 import argparse
 import os
-from khmer import MinHash
+from sourmash_lib._minhash import MinHash
 
 
 KSIZE=31

--- a/search-catlas-mh.py
+++ b/search-catlas-mh.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 import argparse
 import os
-from sourmash_lib._minhash import MinHash
+from sourmash_lib import MinHash
 
 
 KSIZE=31

--- a/search-dbg.py
+++ b/search-dbg.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 from __future__ import print_function
 import argparse
-from khmer import MinHash
+from sourmash_lib._minhash import MinHash
 from spacegraphcats import graph_parser
 from spacegraphcats.catlas_reader import CAtlasReader
 import os

--- a/search-dbg.py
+++ b/search-dbg.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 from __future__ import print_function
 import argparse
-from sourmash_lib._minhash import MinHash
+from sourmash_lib import MinHash
 from spacegraphcats import graph_parser
 from spacegraphcats.catlas_reader import CAtlasReader
 import os

--- a/search-for-domgraph-nodes-multi.py
+++ b/search-for-domgraph-nodes-multi.py
@@ -3,9 +3,9 @@
 """
 from __future__ import print_function
 import argparse
-from khmer import MinHash
 from spacegraphcats import graph_parser
 from spacegraphcats.catlas_reader import CAtlasReader
+from sourmash_lib._minhash import MinHash
 import os
 import sys
 

--- a/search-for-domgraph-nodes-multi.py
+++ b/search-for-domgraph-nodes-multi.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 import argparse
 from spacegraphcats import graph_parser
 from spacegraphcats.catlas_reader import CAtlasReader
-from sourmash_lib._minhash import MinHash
+from sourmash_lib import MinHash
 import os
 import sys
 

--- a/search-for-domgraph-nodes.py
+++ b/search-for-domgraph-nodes.py
@@ -3,7 +3,7 @@
 """
 from __future__ import print_function
 import argparse
-from sourmash_lib._minhash import MinHash
+from sourmash_lib import MinHash
 from spacegraphcats import graph_parser
 from spacegraphcats.catlas_reader import CAtlasReader
 from spacegraphcats.catlas import CAtlas

--- a/search-for-domgraph-nodes.py
+++ b/search-for-domgraph-nodes.py
@@ -3,7 +3,7 @@
 """
 from __future__ import print_function
 import argparse
-from khmer import MinHash
+from sourmash_lib._minhash import MinHash
 from spacegraphcats import graph_parser
 from spacegraphcats.catlas_reader import CAtlasReader
 from spacegraphcats.catlas import CAtlas

--- a/spacegraphcats/catlas.py
+++ b/spacegraphcats/catlas.py
@@ -9,7 +9,7 @@ from operator import itemgetter
 from spacegraphcats.graph import Graph, VertexDict
 from spacegraphcats.rdomset import rdomset, calc_domination_graph, calc_dominators
 from spacegraphcats.graph_parser import parse_minhash, Writer
-from sourmash_lib._minhash import MinHash
+from sourmash_lib import MinHash
 
 KSIZE=31
 

--- a/spacegraphcats/catlas.py
+++ b/spacegraphcats/catlas.py
@@ -9,7 +9,7 @@ from operator import itemgetter
 from spacegraphcats.graph import Graph, VertexDict
 from spacegraphcats.rdomset import rdomset, calc_domination_graph, calc_dominators
 from spacegraphcats.graph_parser import parse_minhash, Writer
-from khmer import MinHash
+from sourmash_lib._minhash import MinHash
 
 KSIZE=31
 

--- a/spacegraphcats/color-domgraph.py
+++ b/spacegraphcats/color-domgraph.py
@@ -12,7 +12,6 @@ catlas nodes 1, 3, and 9 in the r-5 catlas.
 """
 import argparse
 import spacegraphcats.graph_parser as parser
-from sourmash_lib._minhash import MinHash
 
 
 def main():

--- a/spacegraphcats/color-domgraph.py
+++ b/spacegraphcats/color-domgraph.py
@@ -12,7 +12,7 @@ catlas nodes 1, 3, and 9 in the r-5 catlas.
 """
 import argparse
 import spacegraphcats.graph_parser as parser
-from khmer import MinHash
+from sourmash_lib._minhash import MinHash
 
 
 def main():

--- a/spacegraphcats/graph.py
+++ b/spacegraphcats/graph.py
@@ -1,7 +1,7 @@
 import sys, itertools, operator
 from collections import defaultdict as defaultdict
 import hashlib
-from sourmash_lib._minhash import MinHash
+from sourmash_lib import MinHash
 
 from spacegraphcats.Eppstein import priorityDictionary, UnionFind
 

--- a/spacegraphcats/graph.py
+++ b/spacegraphcats/graph.py
@@ -1,6 +1,7 @@
 import sys, itertools, operator
 from collections import defaultdict as defaultdict
 import hashlib
+from sourmash_lib._minhash import MinHash
 
 from spacegraphcats.Eppstein import priorityDictionary, UnionFind
 
@@ -20,7 +21,6 @@ class VertexDict(dict):
 
     @classmethod
     def from_mxt(cls, file, ksize=31):
-        from khmer import MinHash
         from .graph_parser import _parse_line
         res = cls()
         for line in file:

--- a/spacegraphcats/search-catlas-levels.py
+++ b/spacegraphcats/search-catlas-levels.py
@@ -2,7 +2,7 @@
 
 import argparse
 import os
-from sourmash_lib._minhash import MinHash
+from sourmash_lib import MinHash
 
 
 def main():

--- a/spacegraphcats/search-catlas-levels.py
+++ b/spacegraphcats/search-catlas-levels.py
@@ -2,7 +2,8 @@
 
 import argparse
 import os
-from khmer import MinHash
+from sourmash_lib._minhash import MinHash
+
 
 def main():
     parser = argparse.ArgumentParser()

--- a/walk-dbg.py
+++ b/walk-dbg.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import sys
 import khmer
+from sourmash_lib._minhash import MinHash
 import screed
 import argparse
 from collections import OrderedDict
@@ -86,7 +87,7 @@ def traverse_and_mark_linear_paths(graph, nk, stop_bf, pathy, degree_nodes):
     v = [ khmer.reverse_hash(i, graph.ksize()) for i in visited ]
     mh_size = max(len(visited) // MH_SIZE_DIVISOR, MH_MIN_SIZE)
 
-    mh = khmer.MinHash(mh_size, graph.ksize())
+    mh = MinHash(mh_size, graph.ksize())
     for kmer in v:
         mh.add_sequence(kmer)
 
@@ -216,7 +217,7 @@ def main():
 
         # add its minhash value.
         k_str = khmer.reverse_hash(k, ksize)
-        mh = khmer.MinHash(1, ksize)
+        mh = MinHash(1, ksize)
         mh.add_sequence(k_str)
         pathy.hashdict[k_id] = mh.get_mins()
 

--- a/walk-dbg.py
+++ b/walk-dbg.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 import sys
 import khmer
-from sourmash_lib._minhash import MinHash
+from sourmash_lib import MinHash
 import screed
 import argparse
 from collections import OrderedDict


### PR DESCRIPTION
The shifts the dependency on khmer.MinHash (which is not in the master branch of khmer) over to the sourmash MinHash implementation.  Since all of the other necessary functionality for spacegraphcats is in the main branch of khmer, this reduces the maintenance burden on both projects but does introduce another dependency.