### PR TITLE
Optionally remove MXT merging from build-catlas.py

### DIFF
--- a/build-catlas.py
+++ b/build-catlas.py
@@ -100,6 +100,8 @@ def main():
                                          as the directory.', type=str)
     parser.add_argument('r', help="The catlas' radius.", type=int )
     parser.add_argument('--min-id', help="Smallest id assigned to catlas nodes.", type=int, default=0)
+    parser.add_argument('--no-merge-mxt', help='do not merge MinHashes',
+                        action='store_true')
     args = parser.parse_args()
 
     project = AttributeDict()
@@ -128,14 +130,18 @@ def main():
 
     report("Loaded graph with {} vertices, {} edges and {} components".format(len(project.graph),project.graph.num_edges(),project.graph.num_components()))
 
-    file = read_project_file(project.path, project.name+".mxt")
-    project.minhashes = VertexDict.from_mxt(file)
+    if not args.no_merge_mxt:
+        file = read_project_file(project.path, project.name+".mxt")
+        project.minhashes = VertexDict.from_mxt(file)
 
-    for v in project.graph:
-        if v not in project.minhashes:
-            warn("Vertex {} is missing minhashes".format(v))
+        for v in project.graph:
+            if v not in project.minhashes:
+                warn("Vertex {} is missing minhashes".format(v))
 
-    report("Loaded minhashes for graph")
+        report("Loaded minhashes for graph")
+    else:
+        report("Per --no-merge-mxt, NOT loading minhashes for graph.")
+        project.minhashes = None
 
 
     """ Compute / load r-dominating set """
@@ -162,4 +168,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/merge-mxt-in-memory.py
+++ b/merge-mxt-in-memory.py
@@ -5,6 +5,7 @@ import argparse
 from sourmash_lib import MinHash
 from collections import defaultdict
 from spacegraphcats.catlas import CAtlas
+import time
 
 
 MINHASH_SIZE=1000
@@ -115,6 +116,8 @@ def main():
     m = 0
     select = lambda node: node.level == 0
     catlas_minhashes = {}
+
+    start_time = time.time()
     for node in catlas.nodes(select):
         assert node.id not in catlas_minhashes
         domgraph_nodes = node.shadow()
@@ -122,11 +125,14 @@ def main():
         catlas_minhashes[node.id] = mins
         n += 1
         m += len(domgraph_nodes)
+    end_time = time.time()
 
     print('level 0: merged {} children into {} nodes'.format(m, n))
+    print('{:.1f} seconds'.format(end_time - start_time))
 
     # for each level above 0, merge the children
     for level in range(1, catlas.level + 1):
+        start_time = time.time()
         print('merging at level:', level)
         n = 0
         m = 0
@@ -138,7 +144,9 @@ def main():
             catlas_minhashes[node.id] = mins
             n += 1
             m += len(node.children)
+        end_time = time.time()
         print('level {}: merged {} children into {} nodes'.format(level, m, n))
+        print('{:.1f} seconds'.format(end_time - start_time))
 
     with open(catmxt, 'wt') as fp:
         n = export_catlas_mxt(catlas_minhashes, fp)

--- a/merge-mxt-in-memory.py
+++ b/merge-mxt-in-memory.py
@@ -12,8 +12,6 @@ MINHASH_K=0
 
 def import_graph_mxt(mxt):
     "Load all of the minhashes from an MXT file into a dict."
-    n = 0
-
     d = {}
     with open(mxt, 'rt') as fp:
         for line in fp:
@@ -23,7 +21,7 @@ def import_graph_mxt(mxt):
 
             d[g_id] = list(map(int, mins.split(' ')))
 
-    return n, d
+    return d
 
 
 def export_catlas_mxt(catlas_minhashes, fp):
@@ -96,8 +94,8 @@ def main():
     dom_to_orig = load_dom_to_orig(assignment_vxt)
     
     # load MXT into dict
-    n, graph_minhashes = import_graph_mxt(graphmxt)
-    print('imported {} graph minhashes'.format(n))
+    graph_minhashes = import_graph_mxt(graphmxt)
+    print('imported {} graph minhashes'.format(len(graph_minhashes)))
 
     # create minhashes for catlas leaf nodes.
     dom_minhashes = {}

--- a/merge-mxt-in-memory.py
+++ b/merge-mxt-in-memory.py
@@ -1,0 +1,152 @@
+#! /usr/bin/env python3
+import os
+import sys
+import argparse
+from sourmash_lib import MinHash
+from collections import defaultdict
+from spacegraphcats.catlas import CAtlas
+
+
+MINHASH_SIZE=1000
+MINHASH_K=0
+
+def import_graph_mxt(mxt):
+    "Load all of the minhashes from an MXT file into a dict."
+    n = 0
+
+    d = {}
+    with open(mxt, 'rt') as fp:
+        for line in fp:
+            line = line.split(',')
+            g_id = int(line[0])
+            mins = line[1]
+
+            d[g_id] = list(map(int, mins.split(' ')))
+
+    return n, d
+
+
+def export_catlas_mxt(catlas_minhashes, fp):
+    "Dump all of the minhashes from 'catlas_minhashes' to an MXT file."
+    n = 0
+
+    for (node_id, mins) in catlas_minhashes.items():
+        fp.write('{},{}\n'.format(node_id, " ".join(map(str, mins))))
+        n += 1
+        
+    return n
+
+
+def merge_nodes(child_dict, child_node_list):
+    """Merge child_node_list from 'from_tablename' into parent_node in
+    'to_tablename'."""
+    minlist = []
+
+    for graph_node in child_node_list:
+        mins = child_dict[graph_node]
+        minlist.append(mins)
+
+    # merge!
+    # (note that minhashes are implicitly merged when you simply add all
+    # the hashes to one MH).
+    merged_mh = MinHash(MINHASH_SIZE, MINHASH_K)
+    for mins in minlist:
+        for h in mins:
+            merged_mh.add_hash(h)
+
+    # add into merged minhashes table.
+    return merged_mh.get_mins()
+
+
+def load_dom_to_orig(assignment_vxt_file):
+    "Load the mapping between dom nodes and the original DBG nodes."
+    dom_to_orig = defaultdict(list)
+    for line in open(assignment_vxt_file, 'rt'):
+        orig_node, dom_list = line.strip().split(',')
+        orig_node = int(orig_node)
+        dom_list = list(map(int, dom_list.split(' ')))
+
+        for dom_node in dom_list:
+            dom_to_orig[dom_node].append(orig_node)
+
+    return dom_to_orig
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('catlas_prefix', help='catlas prefix')
+    p.add_argument('catlas_r', help='catlas radius', type=int)
+    args = p.parse_args()
+    
+    radius = args.catlas_r
+    basename = os.path.basename(args.catlas_prefix)
+    graphmxt = '%s.mxt' % (basename,)
+    graphmxt = os.path.join(args.catlas_prefix, graphmxt)
+    
+    catgxt = '%s.catlas.%d.gxt' % (basename, radius)
+    catmxt = '%s.catlas.%d.mxt' % (basename, radius)
+    catgxt = os.path.join(args.catlas_prefix, catgxt)
+    catmxt = os.path.join(args.catlas_prefix, catmxt)
+
+    catmxt_db = catmxt + '.db'
+
+    # load mapping between dom nodes and cDBG/graph nodes:
+    assignment_vxt = '%s.assignment.%d.vxt' % (basename, radius)
+    assignment_vxt = os.path.join(args.catlas_prefix, assignment_vxt)
+    dom_to_orig = load_dom_to_orig(assignment_vxt)
+    
+    # load MXT into dict
+    n, graph_minhashes = import_graph_mxt(graphmxt)
+    print('imported {} graph minhashes'.format(n))
+
+    # create minhashes for catlas leaf nodes.
+    dom_minhashes = {}
+    for n, (dom_node, graph_nodes) in enumerate(dom_to_orig.items()):
+        mins = merge_nodes(graph_minhashes, graph_nodes)
+        dom_minhashes[dom_node] = mins
+    print('created {} leaf node MinHashes via merging'.format(n + 1))
+
+    # this gives us the leaf level minhashes that we need for the rest.
+    # now, eliminate the assignment dict & go for the catlas structure.
+    del dom_to_orig
+    catlas = CAtlas.read(catgxt, None, args.catlas_r)
+
+    # for level 0, merge the shadows (domgraph nodes)
+    print('merging level 0')
+    n = 0
+    m = 0
+    select = lambda node: node.level == 0
+    catlas_minhashes = {}
+    for node in catlas.nodes(select):
+        assert node.id not in catlas_minhashes
+        domgraph_nodes = node.shadow()
+        mins = merge_nodes(dom_minhashes, domgraph_nodes)
+        catlas_minhashes[node.id] = mins
+        n += 1
+        m += len(domgraph_nodes)
+
+    print('level 0: merged {} children into {} nodes'.format(m, n))
+
+    # for each level above 0, merge the children
+    for level in range(1, catlas.level + 1):
+        print('merging at level:', level)
+        n = 0
+        m = 0
+        select = lambda node: node.level == level
+        for node in catlas.nodes(select):
+            assert node.id not in catlas_minhashes
+            mins = merge_nodes(catlas_minhashes,
+                               [ x.id for x in node.children ])
+            catlas_minhashes[node.id] = mins
+            n += 1
+            m += len(node.children)
+        print('level {}: merged {} children into {} nodes'.format(level, m, n))
+
+    with open(catmxt, 'wt') as fp:
+        n = export_catlas_mxt(catlas_minhashes, fp)
+        print('exported {} catlas minhashes to {}'.format(n, catmxt))
+
+    sys.exit(0)
+
+if __name__ == '__main__':
+    main()

--- a/merge-mxt-on-disk.py
+++ b/merge-mxt-on-disk.py
@@ -157,6 +157,7 @@ def main():
         n += 1
         m += len(domgraph_nodes)
     print('level 0: merged {} children into {} nodes'.format(m, n))
+    conn.commit()
 
     # for each level above 0, merge the children
     for level in range(1, catlas.level + 1):
@@ -170,7 +171,7 @@ def main():
             n += 1
             m += len(node.children)
         print('level {}: merged {} children into {} nodes'.format(level, m, n))
-    conn.commit()
+        conn.commit()
 
     with open(catmxt, 'wt') as fp:
         n = export_catlas_mxt(conn, fp)

--- a/merge-mxt-on-disk.py
+++ b/merge-mxt-on-disk.py
@@ -1,0 +1,136 @@
+#! /usr/bin/env python3
+import os
+import sys
+import sqlite3
+import argparse
+from sourmash_lib import MinHash
+from collections import defaultdict
+
+
+MINHASH_SIZE=1000
+MINHASH_K=0
+
+
+def connect_db(filepath):
+    conn = sqlite3.connect(filepath)
+    cur = conn.cursor()
+    
+    cur.execute("PRAGMA synchronous='OFF'")
+    cur.execute("PRAGMA locking_mode=EXCLUSIVE")
+
+    cur.execute('''CREATE TABLE graph_minhashes (node_id INTEGER PRIMARY KEY,
+                                                 mins TEXT)''')
+    cur.execute('''CREATE TABLE catlas_minhashes (node_id INTEGER PRIMARY KEY,
+                                                  mins TEXT)''')
+
+    return conn
+
+def import_graph_mxt(conn, mxt):
+    n = 0
+    with open(mxt, 'rt') as fp:
+        cur = conn.cursor()
+        
+        for line in fp:
+            line = line.split(',')
+            g_id = int(line[0])
+            mins = line[1]
+
+            cur.execute('INSERT INTO graph_minhashes (node_id, mins) VALUES (?, ?)', (g_id, mins))
+            n += 1
+
+    conn.commit()
+
+    return n
+
+
+def export_catlas_mxt(conn, fp):
+    n = 0
+    cur = conn.cursor()
+
+    cur.execute('SELECT node_id, mins FROM catlas_minhashes')
+    for (node_id, mins) in cur:
+        fp.write('{},{}\n'.format(node_id, mins))
+        n += 1
+        
+    return n
+
+
+def merge_graph_nodes(cur, graph_node_list, catlas_node):
+    minlist = []
+
+    for graph_node in graph_node_list:
+        cur.execute('SELECT mins FROM graph_minhashes WHERE node_id=?', (graph_node,))
+        mins = cur.fetchone()[0]
+        mins = list(map(int, mins.split()))
+        minlist.append(mins)
+
+    # merge (note that minhashes are implicitly merged when you simply add all
+    # the hashes to one MH).
+    merged_mh = MinHash(MINHASH_SIZE, MINHASH_K)
+    for mins in minlist:
+        print('XXX', mins)
+        for h in mins:
+            merged_mh.add_hash(h)
+
+    # add
+    merged_mins = " ".join(map(str, merged_mh.get_mins()))
+    print('YYY', merged_mins)
+    cur.execute('INSERT INTO catlas_minhashes (node_id, mins) VALUES (?, ?)',
+                (catlas_node, merged_mins))
+
+
+def load_dom_to_orig(assignment_vxt_file):
+    "Load the mapping between level0/dom nodes and the original DBG nodes."
+    dom_to_orig = defaultdict(list)
+    for line in open(assignment_vxt_file, 'rt'):
+        orig_node, dom_list = line.strip().split(',')
+        orig_node = int(orig_node)
+        dom_list = list(map(int, dom_list.split(' ')))
+
+        for dom_node in dom_list:
+            dom_to_orig[dom_node].append(orig_node)
+
+    return dom_to_orig
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('catlas_prefix', help='catlas prefix')
+    p.add_argument('catlas_r', help='catlas radius', type=int)
+    args = p.parse_args()
+    
+    radius = args.catlas_r
+    basename = os.path.basename(args.catlas_prefix)
+    graphmxt = '%s.mxt' % (basename,)
+    graphmxt = os.path.join(args.catlas_prefix, graphmxt)
+    
+    catgxt = '%s.catlas.%d.gxt' % (basename, radius)
+    catmxt = '%s.catlas.%d.mxt' % (basename, radius)
+    catgxt = os.path.join(args.catlas_prefix, catgxt)
+    catmxt = os.path.join(args.catlas_prefix, catmxt)
+
+    catmxt_db = catmxt + '.db'
+
+    # load mapping between dom nodes and cDBG/graph nodes:
+    assignment_vxt = '%s.assignment.%d.vxt' % (basename, radius)
+    assignment_vxt = os.path.join(args.catlas_prefix, assignment_vxt)
+    dom_to_orig = load_dom_to_orig(assignment_vxt)
+    
+    # load MXT into sqlite database
+    conn = connect_db(catmxt_db)
+    n = import_graph_mxt(conn, graphmxt)
+    print('imported {} graph minhashes'.format(n))
+
+    cur = conn.cursor()
+    for dom_node, graph_nodes in dom_to_orig.items():
+        merge_graph_nodes(cur, graph_nodes, dom_node)
+    conn.commit()
+
+    with open(catmxt, 'wt') as fp:
+        n = export_catlas_mxt(conn, fp)
+        print('exported {} catlas minhashes to {}'.format(n, catmxt))
+
+    sys.exit(0)
+
+if __name__ == '__main__':
+    main()

--- a/merge-mxt-on-disk.py
+++ b/merge-mxt-on-disk.py
@@ -165,7 +165,7 @@ def main():
         m = 0
         select = lambda node: node.level == level
         for node in catlas.nodes(select):
-            merge_nodes(cur, [ n.id for n in node.children ],
+            merge_nodes(cur, [ x.id for x in node.children ],
                         node.id, 'catlas_minhashes', 'catlas_minhashes')
             n += 1
             m += len(node.children)

--- a/merge-mxt-on-disk.py
+++ b/merge-mxt-on-disk.py
@@ -156,7 +156,7 @@ def main():
                     'catlas_minhashes')
         n += 1
         m += len(domgraph_nodes)
-    print('level 0: merged {} children into {} nodes'.format(n, m))
+    print('level 0: merged {} children into {} nodes'.format(m, n))
 
     # for each level above 0, merge the children
     for level in range(1, catlas.level + 1):
@@ -169,7 +169,7 @@ def main():
                         node.id, 'catlas_minhashes', 'catlas_minhashes')
             n += 1
             m += len(node.children)
-        print('level {}: merged {} children into {} nodes'.format(level, n, m))
+        print('level {}: merged {} children into {} nodes'.format(level, m, n))
     conn.commit()
 
     with open(catmxt, 'wt') as fp:

--- a/spacegraphcats/test_cmd_line.py
+++ b/spacegraphcats/test_cmd_line.py
@@ -161,7 +161,7 @@ def test_search_new_catlas_merge_mxt_on_disk():
         assert not os.path.exists(catlas_mxt)
 
         # run merge
-        utils.runscript('merge-mxt-on-disk.py', [dirname, '5'])
+        utils.runscript('merge-mxt-in-memory.py', [dirname, '5'])
         assert os.path.exists(catlas_mxt)
 
         status, out, err = utils.runscript('search-catlas-mh.py',


### PR DESCRIPTION
The majority of memory usage during catlas construction seems to be coming from keeping the MinHashes in memory. This PR provides an option that turns off MinHash loading and computation in `build-catlas.py`, and further provides `merge-mxt-on-disk.py`, a slower but more memory efficient merge script that uses an on-disk sqlite3 database, and `merge-mxt-in-memory.py`, a faster but still more memory-efficient merge script that works in RAM.

Results on the ~100m read Podar data set, which has 1882162 vertices, 2021493 edges and 30711 components:

* `build-catlas.py XXX 5` requires > 15 GB of RAM (as in, doesn't complete on a 15 GB machine).
* `build-catlas.py --no-merge-mxt XXX 5` requires about 6 GB of RAM.
* `merge-mxt-on-disk.py XXX 5` requires < 1 GB of RAM.

Also note that building the catlas requires just under 2 hours on an AWS m4.xlarge machine, which is pretty good IMO.  Sadly, the on-disk merge is quite slow (~9000 seconds) but there are probably some simple things to be done about that.

The final catlas is about 7 GB in memory.

The Podar data set gxt/mxt is about 100 MB zipped... I'll stash it on S3 somewhere for people that want to work with it.

In any case, the memory usage is now small enough that I can go play with some other, bigger data sets - huzzah!