### PR TITLE
Replaced next(iter(...)) by .pop(). Twice as fast.

### DIFF
--- a/spacegraphcats/graph.py
+++ b/spacegraphcats/graph.py
@@ -201,7 +201,7 @@ class Graph:
         while len(removed) < n:
             while len(degbuckets[mindeg]) == 0:
                 mindeg += 1
-            v =degbuckets[mindeg].pop(v)
+            v = degbuckets[mindeg].pop()
             removed.add(v)
             degen = max(degen, mindeg)
 

--- a/spacegraphcats/graph.py
+++ b/spacegraphcats/graph.py
@@ -1,7 +1,6 @@
 import sys, itertools, operator
 from collections import defaultdict as defaultdict
 import hashlib
-from sourmash_lib import MinHash
 
 from spacegraphcats.Eppstein import priorityDictionary, UnionFind
 
@@ -22,6 +21,7 @@ class VertexDict(dict):
     @classmethod
     def from_mxt(cls, file, ksize=31):
         from .graph_parser import _parse_line
+        from sourmash_lib import MinHash
         res = cls()
         for line in file:
             u, hashes = _parse_line(line)
@@ -201,8 +201,7 @@ class Graph:
         while len(removed) < n:
             while len(degbuckets[mindeg]) == 0:
                 mindeg += 1
-            v = next(iter(degbuckets[mindeg]))
-            degbuckets[mindeg].remove(v)
+            v =degbuckets[mindeg].pop(v)
             removed.add(v)
             degen = max(degen, mindeg)
 

--- a/spacegraphcats/rdomset.py
+++ b/spacegraphcats/rdomset.py
@@ -168,8 +168,7 @@ def ldo(g, weight=None):
         d = 0
         while len(buckets[d]) == 0:
             d += 1
-        v = next(iter(buckets[d]))
-        buckets[d].remove(v)
+        v = buckets[d].pop()
 
         for u in g.neighbours(v):
             if u in seen:


### PR DESCRIPTION
Well. The commit says is all. I removed two inefficiencies stemming
from my early python days. This simple change makes `ldo()` and `calc_degeneracy()`
roughly twice as fast. 