### PR TITLE
Dom/purgatory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ acido-search: acido/minhashes.db acido/acido-chunk1.fa.gz.sig
 acido-frontier-search: acido/minhashes.db acido/acido-chunk1.fa.gz.sig
 	python -m search.frontier_search acido/acido-chunk1.fa.gz.sig acido 0.1
 
+acido-frontier-search-optimized: acido/minhashes.db acido/acido-chunk1.fa.gz.sig
+	python -m search.frontier_search acido/acido-chunk1.fa.gz.sig acido 0.1  --purgatory
+
+
 ### 
 
 15genome-clean:

--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,6 @@ acido-frontier-search: acido/minhashes.db acido/acido-chunk1.fa.gz.sig
 
 15genome-frontier-search: 15genome/minhashes.db
 	python -m search.frontier_search data/15genome.5.fa.sig 15genome 0.1
+
+15genome-frontier-search-optimized: 15genome/minhashes.db
+	python -m search.frontier_search data/15genome.5.fa.sig 15genome 0.1 --purgatory

--- a/search/frontier_search.py
+++ b/search/frontier_search.py
@@ -67,23 +67,23 @@ def frontier_search(query_sig, top_node_id: int, dag, minhash_db: Union[str, lev
     num_empty = 0
 
     @memoize
-    def load_and_downsample_minhash(node_id: int):
+    def load_and_downsample_minhash(node_id: int) -> MinHash:
         minhash = load_minhash(node_id, minhash_db)
         if minhash is None:
             return None
         return minhash.downsample_max_hash(query_sig.minhash)
 
     @memoize
-    def get_query_minhash(scaled: int):
+    def get_query_minhash(scaled: int) -> MinHash:
         return query_sig.minhash.downsample_scaled(scaled)
 
     @memoize
-    def node_overhead(minhash: MinHash):
+    def node_overhead(minhash: MinHash) -> float:
         query_mh = get_query_minhash(minhash.scaled)
         return compute_overhead(minhash, query_mh)
 
     @memoize
-    def node_containment(minhash: MinHash):
+    def node_containment(minhash: MinHash) -> float:
         query_mh = get_query_minhash(minhash.scaled)
         return query_mh.contained_by(minhash)
 

--- a/search/frontier_search.py
+++ b/search/frontier_search.py
@@ -194,7 +194,7 @@ def frontier_search(query_sig, top_node_id: int, dag, minhash_db: Union[str, lev
     # now check whether the nodes in the purgatory are still necessary
     if len(purgatory):
         purgatory.sort()
-        required_query_minhashes = set(query_sig.minhash.get_mins()) - set(frontier_minhash.get_mins())
+        required_query_minhashes = query_sig.minhash.subtract_mins(frontier_minhash)
         for _, node_id, node_mh in purgatory:
             before = len(required_query_minhashes)
             required_query_minhashes -= set(node_mh.get_mins())

--- a/search/frontier_search.py
+++ b/search/frontier_search.py
@@ -59,7 +59,7 @@ def frontier_search(query_sig, top_node_id: int, dag, minhash_db: Union[str, lev
     frontier_minhash = None
 
     # nodes and minhashes for leaves with large overhead
-    purgatory = []  # type: List[Tuple[int, int, MinHash]]
+    purgatory = []  # type: List[Tuple[float, int, MinHash]]
 
     seen_nodes = set()  # type: Set[int]
 
@@ -94,7 +94,7 @@ def frontier_search(query_sig, top_node_id: int, dag, minhash_db: Union[str, lev
             if frontier_minhash:
                 frontier_minhash.merge(minhash)
             else:
-                frontier_minhash = minhash
+                frontier_minhash = copy(minhash)
 
     def add_to_frontier(node_id: int):
         """
@@ -178,7 +178,7 @@ def frontier_search(query_sig, top_node_id: int, dag, minhash_db: Union[str, lev
                     # early termination, all children already cover the node so we can stop
                     return
 
-            union_contain = get_query_minhash(union.scaled).contained_by(union)
+            union_contain = query_mh.contained_by(union)
             if union_contain < containment:
                 raise Exception('Children cannot cover node: {} vs {}'.format(union_contain, containment))
 

--- a/search/frontier_search.py
+++ b/search/frontier_search.py
@@ -36,7 +36,8 @@ def find_shadow(nodes: List[int], dag: Dict[int, List[int]]) -> Set[int]:
     return shadow
 
 def compute_overhead(node_minhash: MinHash, query_minhash: MinHash) -> float:
-    """ Compute the relative overhead of minhashes. """
+    """ Compute the relative overhead of minhashes.
+    That is, the number of minhashes that are also in the query divides by the number of minhashes. """
     node_length = len(node_minhash.get_mins())
     return (node_length - node_minhash.count_common(query_minhash)) / node_length
 
@@ -96,15 +97,15 @@ def frontier_search(query_sig, top_node_id: int, dag, minhash_db: Union[str, lev
         else:
             seen_nodes.add(node_id)
 
+        minhash = load_and_downsample_minhash(node_id)
+
         children_ids = dag[node_id]
         if len(children_ids) == 0:
             # leaf
             nonlocal num_leaves
-            add_node(node_id, load_minhash(node_id, minhash_db))
+            add_node(node_id, minhash)
             num_leaves += 1
             return
-
-        minhash = load_and_downsample_minhash(node_id)
 
         # check whether the node has more than x% overhead
 
@@ -169,7 +170,7 @@ def frontier_search(query_sig, top_node_id: int, dag, minhash_db: Union[str, lev
 
         else:
             # low overhead node
-            add_node(node_id, load_minhash(node_id, minhash_db))
+            add_node(node_id, minhash)
 
     add_to_frontier(top_node_id)
 

--- a/search/frontier_search.py
+++ b/search/frontier_search.py
@@ -21,6 +21,7 @@ def find_shadow(nodes: List[int], dag: Dict[int, List[int]]) -> Set[int]:
     def add_to_shadow(node_id: int):
         if node_id in seen_nodes:
             return
+        seen_nodes.add(node_id)
 
         children_ids = dag[node_id]
 

--- a/search/memoize.py
+++ b/search/memoize.py
@@ -6,6 +6,8 @@ def memoize(func):
     def memoized_func(*args, **kwargs):
         key = str(args) + str(kwargs)
         if key not in cache:
-            cache[key] = func(*args, **kwargs)
+            val = func(*args, **kwargs)
+            cache[key] = val
+            return val
         return cache[key]
     return memoized_func


### PR DESCRIPTION
# Before

```
make acido-frontier-search
python -m search.frontier_search acido/acido-chunk1.fa.gz.sig acido 0.1
loaded 1631 nodes from catlas acido/catlas.csv
loaded query sig data/acido-chunk1.fa.gz
Root containment: 1.0
Root similarity: 0.1331573896353167
Containment of frontier: 1.0
Similarity of frontier: 0.7827926657263752
Size of frontier: 69 of 1631 (4.23%)
Overhead of frontier: 0.21720733427362482
Number of leaves in the frontier: 15
Number of empty catlas nodes in the frontier: 36
Size of the shadow: 193
```

```
make 15genome-frontier-search                                                                                                                          486ms
python -m search.frontier_search data/15genome.5.fa.sig 15genome 0.1
loaded 40322 nodes from catlas 15genome/catlas.csv
loaded query sig 15genome.5.fa
Root containment: 1.0
Root similarity: 0.09282589676290463
Containment of frontier: 1.0
Similarity of frontier: 0.900679117147708
Size of frontier: 1134 of 40322 (2.81%)
Overhead of frontier: 0.09932088285229201
Number of leaves in the frontier: 271
Number of empty catlas nodes in the frontier: 541
Size of the shadow: 2744
```

# After 

```
make acido-frontier-search                                                                                                                     2746ms
python -m search.frontier_search acido/acido-chunk1.fa.gz.sig acido 0.1
loaded 1631 nodes from catlas acido/catlas.csv
loaded query sig data/acido-chunk1.fa.gz
Root containment: 1.0
Root similarity: 0.1331573896353167
Containment of frontier: 1.0
Similarity of frontier: 0.7827926657263752
Size of frontier: 69 of 1631 (4.23%)
Overhead of frontier: 0.21720733427362482
Number of leaves in the frontier: 15
Number of empty catlas nodes in the frontier: 36
Size of the shadow: 721
```

```
make 15genome-frontier-search                                                                                                               419ms
python -m search.frontier_search data/15genome.5.fa.sig 15genome 0.1
loaded 40322 nodes from catlas 15genome/catlas.csv
loaded query sig 15genome.5.fa
Root containment: 1.0
Root similarity: 0.09282589676290463
Containment of frontier: 1.0
Similarity of frontier: 0.900679117147708
Size of frontier: 1134 of 40322 (2.81%)
Overhead of frontier: 0.09932088285229201
Number of leaves in the frontier: 271
Number of empty catlas nodes in the frontier: 541
Size of the shadow: 23965
```

# with purgatory

```
make acido-frontier-search-optimized                                                                                                           2568ms
python -m search.frontier_search acido/acido-chunk1.fa.gz.sig acido 0.1  --purgatory
loaded 1631 nodes from catlas acido/catlas.csv
loaded query sig data/acido-chunk1.fa.gz
Root containment: 1.0
Root similarity: 0.1331573896353167
Containment of frontier: 1.0
Similarity of frontier: 0.9024390243902439
Size of frontier: 66 of 1631 (4.05%)
Overhead of frontier: 0.0975609756097561
Number of leaves in the frontier: 12
Number of empty catlas nodes in the frontier: 36
Size of the shadow: 721
```

```
make 15genome-frontier-search-optimized                                                                                                        2407ms
python -m search.frontier_search data/15genome.5.fa.sig 15genome 0.1 --purgatory
loaded 40322 nodes from catlas 15genome/catlas.csv
loaded query sig 15genome.5.fa
Root containment: 1.0
Root similarity: 0.09282589676290463
Containment of frontier: 1.0
Similarity of frontier: 0.9498657117278424
Size of frontier: 1095 of 40322 (2.72%)
Overhead of frontier: 0.050134288272157566
Number of leaves in the frontier: 232
Number of empty catlas nodes in the frontier: 541
Size of the shadow: 23965
```