### PR TITLE
Add a more manageable "real read" data set for testing - the shewanella reads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ shew-reads/minhashes.db: shew-reads/catlas.csv shew-reads/contigs.fa.gz
 
 # download the shewanella genome from OSF
 shew-reads/shewanella.fa.gz:
+	mkdir -p shew-reads
 	curl -L 'https://osf.io/fx4ew/?action=download' > shew-reads/shewanella.fa.gz
 
 # compute shewanella genome signature

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ XXXshewanella.abundtrim.gz:
 
 # download the prepared reads (27 MB) from OSF
 shewanella.abundtrim.gz:
-	curl -L 'https://osf.io/7az9p/?action=download&version=1' > shewanella.abundtrim.gz
+	curl -L 'https://osf.io/7az9p/?action=download' > shewanella.abundtrim.gz
 
 # build cDBG
 shew-reads/cdbg.gxt: shewanella.abundtrim.gz
@@ -94,3 +94,15 @@ shew-reads/catlas.csv: shew-reads/cdbg.gxt
 # build minhashes
 shew-reads/minhashes.db: shew-reads/catlas.csv shew-reads/contigs.fa.gz
 	python -m search.make_catlas_minhashes -k 31 --scaled=1000 shew-reads
+
+# download the shewanella genome from OSF
+shew-reads/shewanella.fa.gz:
+	curl -L 'https://osf.io/fx4ew/?action=download' > shew-reads/shewanella.fa.gz
+
+# compute shewanella genome signature
+shew-reads/shewanella.fa.gz.sig: shew-reads/shewanella.fa.gz
+	sourmash compute -k 31 --scaled=1000 shew-reads/shewanella.fa.gz -o shew-reads/shewanella.fa.gz.sig
+
+# run frontier search
+shew-search: shew-reads/shewanella.fa.gz.sig shew-reads/minhashes.db
+	python -m search.frontier_search shew-reads/shewanella.fa.gz.sig shew-reads 0.1 --purgatory

--- a/Makefile
+++ b/Makefile
@@ -65,3 +65,32 @@ acido-frontier-search-optimized: acido/minhashes.db acido/acido-chunk1.fa.gz.sig
 
 15genome-frontier-search-optimized: 15genome/minhashes.db
 	python -m search.frontier_search data/15genome.5.fa.sig 15genome 0.1 --purgatory
+
+####
+
+#
+# shewanella.mappedreads.fa is a collection of reads from podar data
+# that maps to the Shewanella OS228 genome via bwa aln.  "Real" data,
+# with known answer.
+#
+
+# prepare reads -- # this is here only for record keeping - never
+# needs to be done again.
+XXXshewanella.abundtrim.gz:
+	trim-low-abund.py --normalize 12 -V -Z 10 -M 2e9 -C 3 -k 21 shewanella.mappedreads.fa -o shewanella.abundtrim.gz --gzip
+
+# download the prepared reads (27 MB) from OSF
+shewanella.abundtrim.gz:
+	curl -L 'https://osf.io/7az9p/?action=download&version=1' > shewanella.abundtrim.gz
+
+# build cDBG
+shew-reads/cdbg.gxt: shewanella.abundtrim.gz
+	python -m spacegraphcats.build_contracted_dbg -k 31 -M 4e9 shewanella.abundtrim.gz -o shew-reads
+
+# build catlas
+shew-reads/catlas.csv: shew-reads/cdbg.gxt
+	python -m spacegraphcats.catlas shew-reads 1
+
+# build minhashes
+shew-reads/minhashes.db: shew-reads/catlas.csv shew-reads/contigs.fa.gz
+	python -m search.make_catlas_minhashes -k 31 --scaled=1000 shew-reads

--- a/spacegraphcats/rdomset.py
+++ b/spacegraphcats/rdomset.py
@@ -2,7 +2,7 @@
 from collections import defaultdict
 from .graph import Graph, DictGraph
 
-from typing import List, Set, Dict, Any, Union, DefaultDict
+from typing import List, Set, Dict, Any, Union
 
 
 def low_degree_orientation(graph: Graph):


### PR DESCRIPTION
It became clear this week that "real" read data sets seem to introduce interesting new features into the cDBG - podar causes many more problems with components and minhashes than acido or 15genome, neither of which use real reads.

This PR introduces a new data set which is a subset of the reads in podar, obtained by mapping the reads from podar against a specific genome sequence.  The read data set is too big to store in github, so I put it in [our OSF project](https://osf.io/6rgzj/) and added a Makefile rule to download it; see target `shewanella.abundtrim.gz` in Makefile.