### PR TITLE
update the podar catlas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,10 +129,10 @@ shew-search: shew-reads/shewanella.fa.gz.sig shew-reads/minhashes.db
 SRR606249.keep.fq.gz:
 	curl -L https://osf.io/45xay/?action=download > SRR606249.keep.fq.gz
 
-# download the prepared catlas/minhashes: 415 MB.
+# download the prepared catlas/minhashes: 250 MB.
 podar-download:
-	curl -L https://osf.io/h79um/?action=download > podar-2017.05.06.tar.gz
-	tar xzf podar-2017.05.06.tar.gz
+	curl -L https://osf.io/g6n4k/?action=download > podar-2017.05.06b.tar.gz
+	tar xzf podar-2017.05.06b.tar.gz
 	touch podar.ng SRR606249.keep.fq.gz podar/*
 
 # load reads into a nodegraph (8 GB in size)


### PR DESCRIPTION
Rebuilt the podar catlas and updated the OSF version to podar-2017.05.06b.tar.gz after merge of #118. Much smaller! Faster! Yay!

Merge when ready.

```
% time python -m search.frontier_search data/mircea-sigs/mircea-rm18.0.fa.sig podar 0.1 --purgatory
loaded 5320993 nodes from catlas podar/catlas.csv
loaded query sig Acidobacterium_capsulatum_ATCC_51196
Root containment: 0.627039627039627
Root similarity: 0.015648632926119836
Containment of frontier: 0.627039627039627
Similarity of frontier: 0.6241299303944315
Size of frontier: 420384 of 5320993 (7.9%)
Overhead of frontier: 0.007380073800738007
Number of leaves in the frontier: 4
Number of empty catlas nodes in the frontier: 420112
Size of the shadow: 1232621
       41.58 real        36.61 user         1.96 sys
```