### PR TITLE
Add in a fix for khmer-related bug, and properly truncate assembled contigs with stop filter.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ screed
 pytest
 leveldb
 https://github.com/dib-lab/sourmash/archive/spacegraphcats.zip
-khmer>=2.1<3
+https://github.com/dib-lab/khmer/archive/spacegraphcats.zip
 numpy

--- a/search/make_catlas_minhashes.py
+++ b/search/make_catlas_minhashes.py
@@ -200,7 +200,9 @@ def main(args=sys.argv[1:]):
 
     # build minhashes for entire catlas, or just the leaves (dom nodes)?
     if not args.leaves_only:
+        print('now building catlas minhashes...')
         build_dag(catlas, leaf_minhashes, factory)
+        print('...done!')
 
     if args.no_minhashes:
         print('per --no-minhashes, NOT building minhashes database.')

--- a/spacegraphcats/walk_dbg.py
+++ b/spacegraphcats/walk_dbg.py
@@ -78,8 +78,8 @@ def traverse_and_mark_linear_paths(graph, nk, stop_bf, pathy, degree_nodes):
 
     # output a contig if requested
     if pathy.assemblyfp:
-        asm = khmer.LinearAssembler(graph)
-        contig = asm.assemble(nk)
+        asm = khmer.LinearAssembler(graph, stop_bf)
+        contig = asm.assemble(graph.reverse_hash(nk))
         pathy.add_assembly(path_id, contig)
 
 
@@ -185,6 +185,7 @@ def run(args):
     # get all of the degree > 2 kmers and give them IDs.
     for kmer in degree_nodes:
         pathy.new_hdn(kmer)
+        stop_bf.add(kmer)
 
     print('traversing linear segments from', len(degree_nodes), 'nodes')
 


### PR DESCRIPTION
This fixes two problems:

* one bug is related to changed behavior in khmer, where 'LinearAssembler.assemble(nk)' requires that nk be a string rather than a hash value (which is incorrect, but needs to be fixed in khmer: see https://github.com/dib-lab/khmer/issues/1765);
* the other bug is in the call to `LinearAssembler`, where a stop_filter should have been used to truncate assembled contigs at high-degree nodes (but wasn't); this fixes the problem.

contigs.fa.gz files will need to be rebuilt (so, `build_contracted_dbg` and minhash related things) but the catlas structure should not change with these updates.