### PR TITLE
[MRG] add loading a nodegraph to dory-test target in Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - python setup.py build_ext --inplace
 script:
   - make lint
+  - make dory-test
   - py.test spacegraphcats search --cov=.
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,8 @@ akker-reads.labels: akker-reads/catlas.csv akker-reads/contigs.fa.gz \
 
 dory-test: data/dory-subset.fa data/dory-head.fa
 	rm -fr dory
-	python -m spacegraphcats.build_contracted_dbg -k 21 data/dory-subset.fa -o dory
+	load-graph.py -k 21 -M 1e8 dory-subset.ng data/dory-subset.fa
+	python -m spacegraphcats.build_contracted_dbg -l dory-subset.ng data/dory-subset.fa -o dory
 	python -m spacegraphcats.catlas dory 1
 	python -m search.make_catlas_minhashes -k 21 --scaled=1000 dory
 	python -m search.make_bgzf data/dory-subset.fa

--- a/spacegraphcats/walk_dbg.py
+++ b/spacegraphcats/walk_dbg.py
@@ -135,11 +135,11 @@ def run(args):
     print('')
     if args.loadgraph:
         print('loading nodegraph from:', args.loadgraph)
-        graph = khmer.Nodegraph.load(args.loadgraph)
+        graph = khmer.load_nodegraph(args.loadgraph)
         print('creating accompanying stopgraph')
         ksize = graph.ksize()
         hashsizes = graph.hashsizes()
-        stop_bf = khmer.Nodegraph(ksize, 1, 1, primes=graph.hashsizes())
+        stop_bf = khmer._Nodegraph(ksize, hashsizes)
     else:
         print('building graphs and loading files')
 


### PR DESCRIPTION
Adjusts `dory-test` target to include building/loading a nodegraph, and adds `dory-test` to the Travis CI.

Fixes #154.
