### PR TITLE
[MRG] Add 'search.catlas_info' to display some basic stats about catlases.

### DIFF
--- a/search/catlas_info.py
+++ b/search/catlas_info.py
@@ -21,7 +21,7 @@ def main():
     contigfile = os.path.join(args.catlas_prefix, "contigs.fa.gz")
 
     top_node_id, dag, dag_up, dag_levels = load_dag(catlas)
-    print('loaded {} nodes from catlas {}'.format(len(dag), catlas))
+    print('loaded {} nodes and {} layers from catlas {}'.format(len(dag), dag_levels[top_node_id], catlas))
 
     print('top catlas node {} has {} children.'.format(top_node_id,
                                                        len(dag[top_node_id])))

--- a/search/catlas_info.py
+++ b/search/catlas_info.py
@@ -43,6 +43,14 @@ def main():
     print('top node minhash has {} mins, k={} scaled={}'.format(len(top_mh.get_mins()), top_mh.ksize, top_mh.scaled))
     print(' => ~{:g} {}-mers total.'.format(len(top_mh.get_mins()) * top_mh.scaled, top_mh.ksize))
 
+    num_empty = 0
+    for child_node in dag[top_node_id]:
+        mh = load_minhash(child_node, minhash_db)
+        if not mh:
+            num_empty += 1
+
+    print('{} empty child nodes (of {}) beneath top node'.format(num_empty, len(dag[top_node_id])))
+
 
 if __name__ == '__main__':
     # import cProfile

--- a/search/catlas_info.py
+++ b/search/catlas_info.py
@@ -1,0 +1,51 @@
+#! /usr/bin/env python
+import argparse
+import os
+import sys
+import leveldb
+
+from .search_utils import (load_dag, load_layer0_to_cdbg, load_minhash)
+from .search_utils import get_minhashdb_name
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('catlas_prefix')
+    p.add_argument('-k', '--ksize', default=31, type=int,
+                   help='list of k-mer sizes (default: 31)')
+    args = p.parse_args()
+
+    basename = os.path.basename(args.catlas_prefix)
+    catlas = os.path.join(args.catlas_prefix, 'catlas.csv')
+    domfile = os.path.join(args.catlas_prefix, 'first_doms.txt')
+    contigfile = os.path.join(args.catlas_prefix, "contigs.fa.gz")
+
+    top_node_id, dag, dag_up, dag_levels = load_dag(catlas)
+    print('loaded {} nodes from catlas {}'.format(len(dag), catlas))
+
+    print('top catlas node {} has {} children.'.format(top_node_id,
+                                                       len(dag[top_node_id])))
+    
+    layer0_to_cdbg = load_layer0_to_cdbg(catlas, domfile)
+    x = set()
+    for v in layer0_to_cdbg.values():
+        x.update(v)
+    print('{} layer 0 catlas nodes, corresponding to {} cDBG nodes.'.format(len(layer0_to_cdbg), len(x)))
+
+    db_path = get_minhashdb_name(args.catlas_prefix, args.ksize, 0, 0)
+    if not db_path:
+        print('** ERROR, minhash DB does not exist for {}'.format(ksize),
+              file=sys.stderr)
+        sys.exit(-1)
+    minhash_db = leveldb.LevelDB(db_path)
+
+    top_mh = load_minhash(top_node_id, minhash_db)
+    print('top node minhash has {} mins, k={} scaled={}'.format(len(top_mh.get_mins()), top_mh.ksize, top_mh.scaled))
+    print(' => ~{:g} {}-mers total.'.format(len(top_mh.get_mins()) * top_mh.scaled, top_mh.ksize))
+
+
+if __name__ == '__main__':
+    # import cProfile
+    # cProfile.run('main()', 'search_stats')
+
+    main()

--- a/search/extract_contigs_by_frontier.py
+++ b/search/extract_contigs_by_frontier.py
@@ -33,7 +33,7 @@ def main():
     p.add_argument('--no-empty', action='store_true')
     p.add_argument('--purgatory', action='store_true')
     p.add_argument('--fullstats', action='store_true')
-    p.add_argument('-k', '--ksize', default=31, type=str,
+    p.add_argument('-k', '--ksize', default='31', type=str,
                    help='list of k-mer sizes (default: 31)')
     p.add_argument('--no-remove-empty', action='store_true')
 

--- a/search/extract_reads_by_frontier.py
+++ b/search/extract_reads_by_frontier.py
@@ -33,7 +33,7 @@ def main():
     p.add_argument('--no-empty', action='store_true')
     p.add_argument('--purgatory', action='store_true')
     p.add_argument('--fullstats', action='store_true')
-    p.add_argument('-k', '--ksize', default=31, type=str,
+    p.add_argument('-k', '--ksize', default='31', type=str,
                    help='k-mer size (default: 31)')
     p.add_argument('--no-remove-empty', action='store_true')
     p.add_argument('--boost-frontier', action='store_true')

--- a/search/frontier_search_batch.py
+++ b/search/frontier_search_batch.py
@@ -29,7 +29,7 @@ def main():
                    default=0.1)
     p.add_argument('--purgatory', action='store_true')
     p.add_argument('-o', '--output', type=argparse.FileType('w'))
-    p.add_argument('-k', '--ksize', default=31, type=str,
+    p.add_argument('-k', '--ksize', default='31', type=str,
                         help='k-mer size (default: 31)')
     p.add_argument('--savedir', default=None)
     args = p.parse_args()


### PR DESCRIPTION
Example output:

```
% python -m search.catlas_info twofoo -k 31
loaded 26041 nodes and 11 layers from catlas twofoo/catlas.csv
top catlas node 26040 has 1271 children.
8523 layer 0 catlas nodes, corresponding to 335388 cDBG nodes.
top node minhash has 10165 mins, k=31 scaled=1000
 => ~1.0165e+07 31-mers total.
581 empty child nodes (of 1271) beneath top node
```

I think some additional useful output might be:

* shadow size of each of the (top_level-1) nodes
* component size distribution (should be approximated by above, no?)
