### PR TITLE
optimize minhash db construction by removing unnecessary intermediate step

### DIFF
--- a/search/make_catlas_minhashes.py
+++ b/search/make_catlas_minhashes.py
@@ -6,6 +6,7 @@ import sys
 import leveldb
 import shutil
 from collections import defaultdict
+import gc
 
 from spacegraphcats.logging import log
 from search import search_utils
@@ -41,10 +42,10 @@ class LevelDBWriter(object):
         self.batch.Put(b, p)
 
 
-def make_contig_minhashes(contigfile, factory):
-    "Make the minhashes for each contig in the contigfile."
+def make_leaf_minhashes(contigfile, cdbg_to_layer0, factory):
+    "Make the minhashes for each leaf node from the contigs in contigfile"
 
-    d = {}
+    d = defaultdict(factory)
     total_bp = 0
     watermark = 1e7
 
@@ -62,10 +63,10 @@ def make_contig_minhashes(contigfile, factory):
         # make a minhash!
         mh = factory()
         mh.add_sequence(record.sequence)
-        if not mh.get_mins():
-            mh = None
-
-        d[cdbg_id] = mh
+        if mh.get_mins():
+            leaf_nodes = cdbg_to_layer0.get(cdbg_id, set())
+            for leaf_node_id in leaf_nodes:
+                d[leaf_node_id].merge(mh)
 
         total_bp += len(record.sequence)
 
@@ -208,12 +209,6 @@ def main(args=sys.argv[1:]):
     catlas = os.path.join(args.catlas_prefix, 'catlas.csv')
     domfile = os.path.join(args.catlas_prefix, 'first_doms.txt')
 
-    # make minhashes from node contigs
-    print('ksize={} scaled={}'.format(ksize, scaled))
-    print('making contig minhashes...')
-    graph_minhashes = make_contig_minhashes(contigfile, factory)
-    print('...made {} contig minhashes'.format(len(graph_minhashes)))
-
     # load mapping between dom nodes and cDBG/graph nodes:
     layer0_to_cdbg = load_layer0_to_cdbg(catlas, domfile)
     print('loaded {} layer 0 catlas nodes'.format(len(layer0_to_cdbg)))
@@ -221,8 +216,15 @@ def main(args=sys.argv[1:]):
     for v in layer0_to_cdbg.values():
         x.update(v)
     print('...corresponding to {} cDBG nodes.'.format(len(x)))
+    del x
 
-    # create the minhash db & remove it if exists
+    # build reverse mapping
+    cdbg_to_layer0 = defaultdict(set)
+    for catlas_node, cdbg_nodes in layer0_to_cdbg.items():
+        for cdbg_id in cdbg_nodes:
+            cdbg_to_layer0[cdbg_id].add(catlas_node)
+
+    # create the minhash db, first removing it if it already exists
     path = search_utils.get_minhashdb_name(args.catlas_prefix, ksize, scaled,
                                            track_abundance, must_exist=False)
     if os.path.exists(path):
@@ -233,24 +235,20 @@ def main(args=sys.argv[1:]):
     save_db.start()                       # batch mode writing
 
     # create minhashes for catlas leaf nodes.
-    catlas_minhashes = {}
-    total_mh = 0
-    empty_mh = 0
-    for n, (catlas_node, cdbg_nodes) in enumerate(layer0_to_cdbg.items()):
-        if n and n % 10000 == 0:
-            print('... built {} leaf node MinHashes...'.format(n),
-                  file=sys.stderr)
-        mh = merge_nodes(graph_minhashes, cdbg_nodes, factory)
-        catlas_minhashes[catlas_node] = mh
+    print('ksize={} scaled={}'.format(ksize, scaled))
+    catlas_minhashes = make_leaf_minhashes(contigfile, cdbg_to_layer0, factory)
+    n = len(catlas_minhashes)
+    print('... built {} leaf node MinHashes...'.format(n),
+          file=sys.stderr)
 
-        total_mh += 1
-        if mh:
-            if save_db:
-                save_db.put_minhash(catlas_node, mh)
-        else:
-            empty_mh += 1                 # track empty
+    total_mh = n
+    empty_mh = len(layer0_to_cdbg) - total_mh
 
-    print('created {} leaf node MinHashes via merging'.format(n + 1))
+    for catlas_node, mh in catlas_minhashes.items():
+        if save_db:
+            save_db.put_minhash(catlas_node, mh)
+
+    print('created {} leaf node MinHashes via merging'.format(n))
     print('')
 
     # build minhashes for entire catlas, or just the leaves (dom nodes)?


### PR DESCRIPTION
Prior to this PR, `search.make_catlas_minhashes` first constructed a minhash for each cDBG node, then combined those into minhashes for each leaf node in the catlas.  This was done for simplicity, but the cDBG node minhashes aren't saved or used. This PR changes minhash construction so that the catlas leaf node minhashes are built directly from the contigs.  This should result in a significant memory savings.
