### PR TITLE
[MRG] enable minhash searches with different seeds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ twofoo.labels: twofoo/contigs.fa.gz twofoo.fq.gz.bgz
 	python -m search.label_cdbg twofoo twofoo.fq.gz.bgz twofoo.labels -k 31 -M 1e9
 
 twofoo-extract-1: twofoo/minhashes_info.json twofoo.labels
-	python -m search.extract_reads data/63.fa.gz twofoo 0.2 twofoo.fq.gz.bgz twofoo.labels twofoo.frontier.63.31.fq --scaled=1000 --seed 43-44
+	python -m search.extract_reads data/63.fa.gz twofoo 0.2 twofoo.fq.gz.bgz twofoo.labels twofoo.frontier.63.31.fq --scaled=1000 --seed 43-47
 
 twofoo-extract-bulk:
 	python -m search.frontier_search_batch twofoo twofoo.fq.gz.bgz twofoo.labels data/2-akker.sig data/47-os185.sig data/63-os223.sig -k 23,25,27,29,31 --savedir foo -o foo/results.csv


### PR DESCRIPTION
Another approach to address https://github.com/TheoryInPractice/cats-in-practice/issues/17.

Briefly, the idea is that we calculate multiple minhash databases with different seeds (independent of the k-mer size) and then search at each of those different seeds.  For now, there is a new search routine, `search.extract_reads`, which takes as input query *sequences* rather than query *signatures* - this is because there is ~poor support in sourmash for saving and loading signatures with multiple seeds.

My proposed workflow is:

* calculate minhash DBs for multiple seeds
* search & extract matches using `search.extract_reads`, avoiding seed=42 which is the default MinHash seed;
* calculate containment and similarity of the extracted reads at seed=42.

- [x] Does this PR change the contracted DBG, catlas, or minhash DB formats?
      If so, merge with care as this will require rebuilding some big files.
