### PR TITLE
CAtlas indexing and isolate removal

### DIFF
--- a/search/make_catlas_minhashes.py
+++ b/search/make_catlas_minhashes.py
@@ -45,7 +45,7 @@ class LevelDBWriter(object):
         self.batch.Put(b, p)
 
 
-def make_leaf_minhashes(contigfile, cdbg_to_layer0, factory):
+def make_leaf_minhashes(contigfile, cdbg_to_layer1, factory):
     "Make the minhashes for each leaf node from the contigs in contigfile"
 
     d = defaultdict(factory)
@@ -67,7 +67,7 @@ def make_leaf_minhashes(contigfile, cdbg_to_layer0, factory):
         mh = factory()
         mh.add_sequence(record.sequence)
         if mh.get_mins():
-            leaf_nodes = cdbg_to_layer0.get(cdbg_id, set())
+            leaf_nodes = cdbg_to_layer1.get(cdbg_id, set())
             for leaf_node_id in leaf_nodes:
                 d[leaf_node_id].merge(mh)
 
@@ -78,7 +78,7 @@ def make_leaf_minhashes(contigfile, cdbg_to_layer0, factory):
     return d
 
 
-def load_layer0_to_cdbg(catlas_file, domfile):
+def load_layer1_to_cdbg(catlas_file, domfile):
     "Load the mapping between first layer catlas and the original DBG nodes."
 
     # mapping from cdbg dominators to dominated nodes.
@@ -95,22 +95,22 @@ def load_layer0_to_cdbg(catlas_file, domfile):
 
     fp.close()
 
-    layer0_to_cdbg = {}
+    layer1_to_cdbg = {}
 
     # mapping from catlas node IDs to cdbg nodes
     fp = open(catlas_file, 'rt')
     for line in fp:
         catlas_node, cdbg_node, level, beneath = line.strip().split(',')
-        if int(level) != 0:
+        if int(level) != 1:
             continue
 
         catlas_node = int(catlas_node)
         cdbg_node = int(cdbg_node)
-        layer0_to_cdbg[catlas_node] = domset[cdbg_node]
+        layer1_to_cdbg[catlas_node] = domset[cdbg_node]
 
     fp.close()
 
-    return layer0_to_cdbg
+    return layer1_to_cdbg
 
 
 def build_catlas_minhashes(catlas_file, catlas_minhashes, factory, save_db):
@@ -124,7 +124,7 @@ def build_catlas_minhashes(catlas_file, catlas_minhashes, factory, save_db):
     fp = open(catlas_file, 'rt')
     for line in fp:
         catlas_node, cdbg_node, level, beneath = line.strip().split(',')
-        if int(level) == 0:
+        if int(level) == 1:
             continue
 
         beneath = beneath.split(' ')
@@ -137,7 +137,7 @@ def build_catlas_minhashes(catlas_file, catlas_minhashes, factory, save_db):
     # single pass on the sorted list).
     x.sort()
     levels = defaultdict(set)
-    current_level = 0
+    current_level = 1
     for (level, catlas_node, beneath) in x:
 
         # remove no-longer needed catlas minhashes to save on memory
@@ -208,8 +208,8 @@ def main(args=sys.argv[1:]):
                              scaled=scaled,
                              track_abundance=args.track_abundance)
     leaf_factory = MinHashFactory(n=0, ksize=ksize,
-                             scaled=leaf_scaled,
-                             track_abundance=args.track_abundance)
+                                  scaled=leaf_scaled,
+                                  track_abundance=args.track_abundance)
 
     # put together the basic catlas info --
     basename = os.path.basename(args.catlas_prefix)
@@ -219,19 +219,19 @@ def main(args=sys.argv[1:]):
     domfile = os.path.join(args.catlas_prefix, 'first_doms.txt')
 
     # load mapping between dom nodes and cDBG/graph nodes:
-    layer0_to_cdbg = load_layer0_to_cdbg(catlas, domfile)
-    print('loaded {} layer 0 catlas nodes'.format(len(layer0_to_cdbg)))
+    layer1_to_cdbg = load_layer1_to_cdbg(catlas, domfile)
+    print('loaded {} layer 1 catlas nodes'.format(len(layer1_to_cdbg)))
     x = set()
-    for v in layer0_to_cdbg.values():
+    for v in layer1_to_cdbg.values():
         x.update(v)
     print('...corresponding to {} cDBG nodes.'.format(len(x)))
     del x
 
     # build reverse mapping
-    cdbg_to_layer0 = defaultdict(set)
-    for catlas_node, cdbg_nodes in layer0_to_cdbg.items():
+    cdbg_to_layer1 = defaultdict(set)
+    for catlas_node, cdbg_nodes in layer1_to_cdbg.items():
         for cdbg_id in cdbg_nodes:
-            cdbg_to_layer0[cdbg_id].add(catlas_node)
+            cdbg_to_layer1[cdbg_id].add(catlas_node)
 
     # create the minhash db, first removing it if it already exists
     path = search_utils.get_minhashdb_name(args.catlas_prefix, ksize, scaled,
@@ -245,14 +245,14 @@ def main(args=sys.argv[1:]):
 
     # create minhashes for catlas leaf nodes.
     print('ksize={} scaled={}'.format(ksize, scaled))
-    catlas_minhashes = make_leaf_minhashes(contigfile, cdbg_to_layer0,
+    catlas_minhashes = make_leaf_minhashes(contigfile, cdbg_to_layer1,
                                            leaf_factory)
     n = len(catlas_minhashes)
     print('... built {} leaf node MinHashes...'.format(n),
           file=sys.stderr)
 
     total_mh = n
-    empty_mh = len(layer0_to_cdbg) - total_mh
+    empty_mh = len(layer1_to_cdbg) - total_mh
 
     for catlas_node, mh in catlas_minhashes.items():
         if save_db:
@@ -278,6 +278,7 @@ def main(args=sys.argv[1:]):
 
     # log that this command was run
     log(args.catlas_prefix, sys.argv)
+
 
 if __name__ == '__main__':
     main()

--- a/spacegraphcats/catlas.py
+++ b/spacegraphcats/catlas.py
@@ -107,12 +107,12 @@ class Project(object):
             root.children = root.children[:unfinished_idx]
             self.level_nodes = {node.vertex: node for node in unfinished}
             self.idx = root.idx
-            self.level = root.level
+            self.level = root.level - 1
             self.root = root
 
     def _save(self):
         """Method used by the thread to write out."""
-        outfile = self.cp_name(self.level)
+        outfile = self.cp_name(self.level - 1)
         print("Writing to file {}".format(outfile))
         with gzip.open(outfile, 'wt') as f:
             # make a dummy root to write the catlas using catlas.write method

--- a/spacegraphcats/graph.py
+++ b/spacegraphcats/graph.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 
 from typing import Callable, List, Tuple, Set, Iterable, Any, Sized
 
+
 class Graph(Iterable, Sized):
     """
     Graph data structure.
@@ -17,7 +18,7 @@ class Graph(Iterable, Sized):
         self.radius = radius
         # lookup the neighbors of a vertex with a given weight
         self.inarcs_by_weight = [[set() for i in range(self.num_nodes)]
-                                 for j in range(self.radius)] # type: Any
+                                 for j in range(self.radius)]  # type: Any
 
     def __iter__(self):
         """Iteration support."""
@@ -70,7 +71,7 @@ class Graph(Iterable, Sized):
         else:
             for x, N in enumerate(self.inarcs_by_weight[weight-1]):
                 for y in N:
-                    yield y,x
+                    yield y, x
 
     def in_neighbors(self, v: int, weight: int=None):
         """Return the inneighbors at a vertex."""
@@ -171,3 +172,17 @@ class DictGraph(Graph):
                     enumerate(self.inarcs_by_weight)
                     for x, N in arc_list.items()
                     for y in N]
+
+    def remove_isolates(self) -> List[int]:
+        """
+        Remove all isolated vertices and return a list of vertices removed.
+
+        Precondition:  the graph is bidirectional
+        """
+        isolates = [v for v in self if self.in_degree(v, 1) == 0]
+        for v in isolates:
+            self.nodes.remove(v)
+            for N in self.inarcs_by_weight:
+                if v in N:
+                    del N[v]
+        return isolates

--- a/spacegraphcats/rdomset.py
+++ b/spacegraphcats/rdomset.py
@@ -294,8 +294,9 @@ def domination_graph(graph: Graph, domset: Set[int], radius: int):
     for u, v in graph.arcs(1):
         du, dv = assigned_dominator[u], assigned_dominator[v]
         assert du in domset and dv in domset
-        domgraph.add_arc(du, dv)
-        domgraph.add_arc(dv, du)
+        if du != dv:
+            domgraph.add_arc(du, dv)
+            domgraph.add_arc(dv, du)
 
     # map of dominators to vertices they dominate
     dominated = {x: set() for x in domset}  # type: Dict[int, Set[int]]

--- a/spacegraphcats/rdomset.py
+++ b/spacegraphcats/rdomset.py
@@ -302,6 +302,8 @@ def domination_graph(graph: Graph, domset: Set[int], radius: int):
     for v, x in assigned_dominator.items():
         dominated[x].add(v)
 
+    domgraph.remove_isolates()
+
     return domgraph, dominated
 
 

--- a/spacegraphcats/rdomset.py
+++ b/spacegraphcats/rdomset.py
@@ -255,7 +255,7 @@ def domination_graph(graph: Graph, domset: Set[int], radius: int):
     (at radius radius) of the original graph.
     """
     print("assigning to dominators")
-    domgraph = DictGraph(nodes=domset)
+    domgraph = DictGraph(nodes=set(domset))
 
     # We need to assign each vertex to a unique closest dominator.  A value of
     # -1 indicates this vertex has not yet been assigned to a dominator.


### PR DESCRIPTION
This fixes #143 by letting level 1 be the leaves rather than level 0.  It also does not propagate up the CAtlas nodes corresponding to components that are simply isolated vertices.  Instead, once a vertex becomes isolated in the domgraph, its corresponding CAtlas node immediately becomes a child of the root.