### PR TITLE
[MRG] Add query name to contigs signature output by extract_nodes_by_query

### DIFF
--- a/search/extract_nodes_by_query.py
+++ b/search/extract_nodes_by_query.py
@@ -360,7 +360,7 @@ def main():
             sig_filename = os.path.basename(query) + '.contigs.sig'
             with open(os.path.join(args.output, sig_filename), 'wt') as fp:
                 ss = sourmash_lib.SourmashSignature(contigs_minhash,
-                                                    name=query_name,
+                                                    name='nbhd:'+query_name,
                                                     filename=sig_filename)
                 sourmash_lib.save_signatures([ss], fp)
 

--- a/search/extract_nodes_by_query.py
+++ b/search/extract_nodes_by_query.py
@@ -210,7 +210,10 @@ def main():
             bf = khmer.Nodetable(ksize, 1, 1)
 
             query_kmers = set()
+            query_name = None
             for record in screed.open(query):
+                if query_name is None:
+                    query_name = record.name
                 query_kmers.update(bf.get_kmer_hashes(record.sequence))
 
             print('got {}'.format(len(query_kmers)))
@@ -357,7 +360,8 @@ def main():
             sig_filename = os.path.basename(query) + '.contigs.sig'
             with open(os.path.join(args.output, sig_filename), 'wt') as fp:
                 ss = sourmash_lib.SourmashSignature(contigs_minhash,
-                                                    name=sig_filename)
+                                                    name=query_name,
+                                                    filename=sig_filename)
                 sourmash_lib.save_signatures([ss], fp)
 
             # write out cDBG IDs


### PR DESCRIPTION
Previously, when outputting each *.contigs.sig file from search, we set the signature name to the filename of the signature itself (which is not very useful). Now set it to `nbhd:` plus the first FASTA header in the query file; this preserves accession information that can be used to get taxonomy, etc.