### PR TITLE
[MRG] Trim low abundance

### DIFF
--- a/conf/Snakefile
+++ b/conf/Snakefile
@@ -29,6 +29,11 @@ search_out_suffix = ''
 if experiment:
     search_out_suffix = '_' + experiment
 
+# remove pendants from bcalm graph? default YES
+remove_pendants = ""
+if config.get('keep_graph_pendants', False):
+    remove_pendants = "-P"
+
 ### build some variables for internal use
 
 catlas_dir = '{}_k{}_r{}'.format(catlas_base, ksize, radius)
@@ -92,7 +97,7 @@ rule bcalm_catlas_input:
         "{catlas_dir}/contigs.fa.gz",
         "{catlas_dir}/contigs.fa.gz.info.csv"
      shell:
-        "{python} -m search.bcalm_to_gxt -k {ksize} {input} {catlas_dir}/cdbg.gxt {catlas_dir}/contigs.fa.gz"
+        "{python} -m search.bcalm_to_gxt {remove_pendants} -k {ksize} {input} {catlas_dir}/cdbg.gxt {catlas_dir}/contigs.fa.gz"
 
 #print(expand("{catlas_dir}/reads.fq.bgz.labels", catlas_dir=catlas_dir))
 

--- a/conf/podarV-noise.json
+++ b/conf/podarV-noise.json
@@ -1,0 +1,11 @@
+{
+    "catlas_base": "podarV-noise",
+    "input_sequences": ["SRR606249.k31.abundtrim.fq.gz"],
+    "ksize": 31,
+    "radius": 1,
+    "keep_graph_pendants": true,
+
+    "searchquick": ["data/2.fa.gz"],
+
+    "search": ["podar-ref/0.fa", "podar-ref/1.fa", "podar-ref/10.fa", "podar-ref/11.fa", "podar-ref/12.fa", "podar-ref/13.fa", "podar-ref/14.fa", "podar-ref/15.fa", "podar-ref/16.fa", "podar-ref/17.fa", "podar-ref/18.fa", "podar-ref/19.fa", "podar-ref/2.fa", "podar-ref/20.fa", "podar-ref/21.fa", "podar-ref/22.fa", "podar-ref/23.fa", "podar-ref/24.fa", "podar-ref/25.fa", "podar-ref/26.fa", "podar-ref/27.fa", "podar-ref/28.fa", "podar-ref/29.fa", "podar-ref/3.fa", "podar-ref/30.fa", "podar-ref/31.fa", "podar-ref/32.fa", "podar-ref/33.fa", "podar-ref/34.fa", "podar-ref/35.fa", "podar-ref/36.fa", "podar-ref/37.fa", "podar-ref/38.fa", "podar-ref/39.fa", "podar-ref/4.fa", "podar-ref/40.fa", "podar-ref/41.fa", "podar-ref/42.fa", "podar-ref/43.fa", "podar-ref/44.fa", "podar-ref/45.fa", "podar-ref/46.fa", "podar-ref/47.fa", "podar-ref/48.fa", "podar-ref/49.fa", "podar-ref/5.fa", "podar-ref/50.fa", "podar-ref/51.fa", "podar-ref/52.fa", "podar-ref/53.fa", "podar-ref/54.fa", "podar-ref/55.fa", "podar-ref/56.fa", "podar-ref/57.fa", "podar-ref/58.fa", "podar-ref/59.fa", "podar-ref/6.fa", "podar-ref/60.fa", "podar-ref/61.fa", "podar-ref/62.fa", "podar-ref/63.fa", "podar-ref/7.fa", "podar-ref/8.fa", "podar-ref/9.fa"]
+}

--- a/conf/twofoo-noise.json
+++ b/conf/twofoo-noise.json
@@ -1,0 +1,13 @@
+{
+    "catlas_base": "twofoo-noise",
+    "input_sequences": ["twofoo.fq.gz"],
+    "ksize": 31,
+    "radius": 1,
+    "keep_graph_pendants": true,
+
+    "searchquick": ["data/63.fa.gz"],
+
+    "search": ["data/2.fa.gz", "data/47.fa.gz", "data/63.fa.gz"],
+
+    "shadow_ratio_maxsize": 1000
+}

--- a/search/bcalm_to_gxt.py
+++ b/search/bcalm_to_gxt.py
@@ -12,6 +12,7 @@ import collections
 import argparse
 from search.bgzf import bgzf
 
+TRIM_CUTOFF = 1.1
 
 def main():
     parser = argparse.ArgumentParser()
@@ -90,10 +91,16 @@ def main():
     # start the gxt file by writing the number of nodes (unitigs))
     gxtfp.write('{}\n'.format(max(link_d.keys()) + 1))
 
+    pendants = set(v for v, N in link_d.items() if len(N)==1)
+
     # write out all of the links, in 'from to' format.
     n_edges = 0
     for node, edgelist in link_d.items():
+        if node in pendants and mean_abunds[node] < TRIM_CUTOFF:
+            continue
         for next_node in edgelist:
+            if next_node in pendants and mean_abunds[next_node] < TRIM_CUTOFF:
+                continue
             assert node <= max_contig_id
             assert next_node <= max_contig_id
             gxtfp.write('{} {}\n'.format(node, next_node))

--- a/search/bcalm_to_gxt.py
+++ b/search/bcalm_to_gxt.py
@@ -79,7 +79,7 @@ def main():
 
         sizes[contig_id] = len(record.sequence) - ksize + 1
 
-    non_pendants = [x for x, N in links_d.items() if len(N) > 1 and \
+    non_pendants = [x for x, N in link_d.items() if len(N) > 1 and \
                     mean_abunds[x] > TRIM_CUTOFF]
     aliases = {x: i for i, x in enumerate(non_pendants)}
     n = len(aliases)


### PR DESCRIPTION
`bcalm_to_gxt.py` now removes pendant vertices with abundance 1 by default; this behavior can be revoked with the `-P` flag.
