### PR TITLE
ignore seqs shorter than ksize in search

### DIFF
--- a/spacegraphcats/search/extract_nodes_by_query.py
+++ b/spacegraphcats/search/extract_nodes_by_query.py
@@ -142,7 +142,8 @@ class Query:
         for record in screed.open(self.filename):
             if self.name is None:
                 self.name = record.name
-            self.kmers.update(bf.get_kmer_hashes(record.sequence))
+            if len(record.sequence) >= int(ksize):
+                self.kmers.update(bf.get_kmer_hashes(record.sequence))
 
         print('got {}'.format(len(self.kmers)))
 


### PR DESCRIPTION
In the _Mus musculus_ refseq txome, there are some contigs <30bp in length, which break "search" with cdbg of ksize = 31. Here's a fix that ignores any contigs smaller than ksize.

Don't think this happens _too_ often. Here are the only two offending contigs in the refseq txome (GRCm38):
```
>NR_028434.1 Mus musculus snoRNA AF357359 (AF357359), small nucleolar RNA
ATCATGACGACAAATTTAATTCTGAGATCA

>NR_028557.1 Mus musculus small nucleolar RNA, C/D box 98 (Snord98), small nucleolar RNA
AATGCAGTGTGGAACATAATGAACTGAA
```