### PR TITLE
[MRG] provide a nicer error message when bcalm fails to run

### DIFF
--- a/spacegraphcats/conf/Snakefile
+++ b/spacegraphcats/conf/Snakefile
@@ -1,9 +1,7 @@
 #
 # Snakemake configuration file for running spacegraphcats pipelines.
 #
-# see script 'run' in this directory for a convenient entry point.
-#
-# Quickstart: `conf/run dory-test searchquick`
+# Quickstart: `spacegraphcats dory-test searchquick`
 #
 from os.path import join
 
@@ -83,7 +81,7 @@ rule bcalm_cdbg:
      output:
         "{catlas_base}/bcalm.{catlas_base}.k{ksize}.unitigs.fa"
      shell:
-        "bcalm -in bcalm.{catlas_base}.k{ksize}.inputlist.txt -out {catlas_base}/bcalm.{catlas_base}.k{wildcards.ksize} -kmer-size {wildcards.ksize} -abundance-min 1 >& {output}.log.txt && rm -f {catlas_base}/bcalm.{catlas_base}.k{wildcards.ksize}.{{h5,unitigs.fa.glue*}}"
+        "(bcalm -in bcalm.{catlas_base}.k{ksize}.inputlist.txt -out {catlas_base}/bcalm.{catlas_base}.k{wildcards.ksize} -kmer-size {wildcards.ksize} -abundance-min 1 >& {output}.log.txt && rm -f {catlas_base}/bcalm.{catlas_base}.k{wildcards.ksize}.{{h5,unitigs.fa.glue*}}) || printf '**\\n**\\n** Cannot run BCALM 2! Please install it and make sure it is on your path!\\n**\\n**\\n'"
 
 # create list of input files for bcalm
 rule bcalm_cdbg_inpfiles:


### PR DESCRIPTION
Fixes https://github.com/spacegraphcats/spacegraphcats/pull/214#issuecomment-449219563 thx @charlesreid1!

Output is now:
```
...
(bbcalm -in bcalm.dory.k21.inputlist.txt -out dory/bcalm.dory.k21 -kmer-size 21 
-abundance-min 1 >& dory/bcalm.dory.k21.unitigs.fa.log.txt && rm -f dory/bcalm.d
ory.k21.{h5,unitigs.fa.glue*}) || printf '**\n**\n** Cannot run BCALM 2! Please 
install it and make sure it is on your path!\n**\n**\n'
**
**
** Cannot run BCALM 2! Please install it and make sure it is on your path!
**
**
Waiting at most 3 seconds for missing files.
...
```