### PR TITLE
add dependency for rule hashval_query

### DIFF
--- a/spacegraphcats/conf/Snakefile
+++ b/spacegraphcats/conf/Snakefile
@@ -282,7 +282,8 @@ rule build_hashval_query_index:
 rule hashval_query:
     input:
         hashval_queries,
-        expand("{hashval_query_dir}/index.pickle", hashval_query_dir=hashval_query_dir)
+        expand("{hashval_query_dir}/index.pickle", hashval_query_dir=hashval_query_dir),
+        expand("{catlas_dir}/catlas.csv", catlas_dir=catlas_dir)
     output:
         expand("{hashval_query_dir}/hashval_results.csv", hashval_query_dir=hashval_query_dir)
 #        make_query_base(config['search']),


### PR DESCRIPTION
rule hashval_query was missing the input file for 'catlas.csv', causing the rule to break from missing file. See comments on #233 