### PR TITLE
[MRG] add unlock to command line

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ screed
 pytest >= 5.1.2
 numpy
 pandas
-snakemake
+snakemake == 5.6.0
 sortedcontainers
 https://github.com/dib-lab/pybbhash/archive/spacegraphcats.zip
 https://github.com/dib-lab/khmer/archive/master.zip

--- a/spacegraphcats/__main__.py
+++ b/spacegraphcats/__main__.py
@@ -47,6 +47,7 @@ from the main spacegraphcats directory.
     parser.add_argument('-n', '--dry-run', action='store_true')
     parser.add_argument('-v', '--verbose', action='store_true')
     parser.add_argument('-d', '--debug', action='store_true')
+    parser.add_argument('--unlock', action='store_true')
     parser.add_argument('--nolock', action='store_true')
     parser.add_argument('--overhead', type=float, default=None)
     parser.add_argument('--experiment', default=None)
@@ -123,7 +124,7 @@ from the main spacegraphcats directory.
     # run!!
     status = snakemake.snakemake(snakefile, configfile=configfile,
                                  targets=args.targets, printshellcmds=True,
-                                 dryrun=args.dry_run,
+                                 dryrun=args.dry_run, unlock=args.unlock,
                                  delete_all_output=args.delete_all_output,
                                  lock=not args.nolock, config=config,
                                  verbose=args.verbose, debug_dag=args.debug)


### PR DESCRIPTION
Adds `--unlock` parameter to the command line to allow [unlock of snakemake processes](https://snakemake.readthedocs.io/en/stable/project_info/faq.html#how-does-snakemake-lock-the-working-directory). Addresses #221. 

Note this still needs to be tested before merge, as spacegraphcats installations were failing from master when I added this.
