### PR TITLE
update requirements.txt to specify snakemake version 5.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ screed
 pytest >= 5.1.2
 numpy
 pandas
-snakemake = 5.6.0
+snakemake == 5.6.0
 sortedcontainers
 https://github.com/dib-lab/pybbhash/archive/spacegraphcats.zip
 https://github.com/dib-lab/khmer/archive/master.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ screed
 pytest >= 5.1.2
 numpy
 pandas
-snakemake
+snakemake = 5.6.0
 sortedcontainers
 https://github.com/dib-lab/pybbhash/archive/spacegraphcats.zip
 https://github.com/dib-lab/khmer/archive/master.zip


### PR DESCRIPTION
Updates snakemake version to 5.6.0 instead of allowing unrestricted version. With the snakemake bump to 5.7.0, f strings were introduced which causes builds to fail for python 3.5. The internal API must have also changed, because the spacegraphcats config file was no longer being handled properly. Addresses errors in #244 and build fails in #246 and #245. 
