### PR TITLE
Add --outdir to spacegraphcats command line

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ screed
 pytest >= 5.1.2
 numpy
 pandas
-snakemake == 5.6.0
+snakemake == 5.8.1
 sortedcontainers
 https://github.com/dib-lab/pybbhash/archive/spacegraphcats.zip
 https://github.com/dib-lab/khmer/archive/master.zip

--- a/spacegraphcats/__main__.py
+++ b/spacegraphcats/__main__.py
@@ -122,7 +122,7 @@ from the main spacegraphcats directory.
         return 0
 
     # run!!
-    status = snakemake.snakemake(snakefile, configfile=configfile,
+    status = snakemake.snakemake(snakefile, configfiles=[configfile],
                                  targets=args.targets, printshellcmds=True,
                                  dryrun=args.dry_run, unlock=args.unlock,
                                  delete_all_output=args.delete_all_output,

--- a/spacegraphcats/__main__.py
+++ b/spacegraphcats/__main__.py
@@ -58,6 +58,7 @@ from the main spacegraphcats directory.
                         help='for paper evaluation purposes')
     parser.add_argument('--version', action='store_true',
                         help='print version and other info.')
+    parser.add_argument('--outdir', help="parent directory of outputs")
     args = parser.parse_args()
 
     if args.version:
@@ -104,6 +105,8 @@ from the main spacegraphcats directory.
         config['radius'] = args.radius
     if args.cdbg_only:
         config['cdbg_only'] = True
+    if args.outdir:
+        config['outdir'] = args.outdir
 
     print('--------', file=sys.stderr)
     print('details!', file=sys.stderr)

--- a/spacegraphcats/cdbg/bcalm_to_gxt.py
+++ b/spacegraphcats/cdbg/bcalm_to_gxt.py
@@ -17,6 +17,7 @@ from spacegraphcats.utils.bgzf import bgzf
 import logging
 from typing import List, Dict, Set
 import sourmash
+import os.path
 
 
 def end_match(s, t, k, direction='sp'):
@@ -237,11 +238,12 @@ def main(argv):
     unitigs = args.bcalm_unitigs
     debug = args.debug
 
+    logfile = os.path.join(os.path.dirname(args.gxt_out), 'bcalm_to_gxt.log')
     if args.debug:
-        logging.basicConfig(filename='bcalm_to_gxt.log', filemode='w',
+        logging.basicConfig(filename=logfile, filemode='w',
                             level=logging.DEBUG)
     else:
-        logging.basicConfig(filename='bcalm_to_gxt.log', filemode='w',
+        logging.basicConfig(filename=logfile, filemode='w',
                             level=logging.WARNING)
 
     logging.debug("starting bcalm_to_gxt run.")

--- a/spacegraphcats/conf/Snakefile
+++ b/spacegraphcats/conf/Snakefile
@@ -5,13 +5,30 @@
 #
 from os.path import join
 
-## pull values in from config file:
+## pull values in from config file / command line:
+
+# set working directory
+startdir = os.getcwd()
+outdir = config.get('outdir')
+if not outdir:
+    outdir = startdir
+
+workdir: outdir
+
+def fix_relative_input_paths(filenames):
+    abs_filenames = []
+    for filename in filenames:
+        if not filename.startswith('/'):
+            print('...updating input file {} with prefix {}'.format(filename, startdir))
+            filename = os.path.join(startdir, filename)
+        abs_filenames.append(filename)
+    return abs_filenames
 
 # name of catlas
 catlas_base = config['catlas_base']
 
 # sequence files to use when building catlas
-input_sequences = config['input_sequences']
+input_sequences = fix_relative_input_paths(config['input_sequences'])
 
 # k-mer size to use for everything
 ksize = config['ksize']
@@ -21,6 +38,10 @@ radius = config['radius']
 
 # search overhead
 overhead = config.get('overhead', 0.0)
+
+# fix paths to searchquick, search files
+config['search'] = fix_relative_input_paths(config.get('search', []))
+config['searchquick'] = fix_relative_input_paths(config.get('search', []))
 
 # paper evaluation: do not expand the cDBG nodes using the domset
 cdbg_only = ""
@@ -46,7 +67,11 @@ decompose_maxsize = config.get('decompose_maxsize', 50000)
 
 # hashval queries / query_by_hashval
 hashval_ksize = config.get('hashval_ksize', ksize)
-hashval_queries = config.get('hashval_queries', '')
+
+hashval_queries = ''
+if config.get('hashval_queries', ''):
+    filename = config.get('hashval_queries', '')
+    hashval_queries = fix_relative_input_paths([filename])[0]
 
 ### build some variables for internal use
 
@@ -61,7 +86,7 @@ onsuccess:
     import os
     print('\n-------- DONE --------\n')
     if os.path.exists(catlas_dir):
-        print('catlas output directory: {}'.format(catlas_dir))
+        print('catlas output directory: {}'.format(catlas_dir)) # @@
         if os.path.exists(search_dir):
             print('search output directory: {}'.format(search_dir))
         print('')

--- a/spacegraphcats/conf/Snakefile
+++ b/spacegraphcats/conf/Snakefile
@@ -106,25 +106,25 @@ rule build:
 
 rule clean:
     shell:
-        "rm -fr {catlas_base} {catlas_dir} {search_dir} bcalm.{catlas_base}.k{ksize}.inputlist.txt bcalm_to_gxt.log"
+        "rm -fr {catlas_base} {catlas_dir} {search_dir}"
 
 # build cDBG using bcalm
 rule bcalm_cdbg:
      input:
-        "bcalm.{catlas_base}.k{ksize}.inputlist.txt"
+        "{catlas_base}/bcalm.{catlas_base}.k{ksize}.inputlist.txt"
      output:
         "{catlas_base}/bcalm.{catlas_base}.k{ksize}.unitigs.fa"
      shell:
-        "(bcalm -in bcalm.{catlas_base}.k{ksize}.inputlist.txt -out {catlas_base}/bcalm.{catlas_base}.k{wildcards.ksize} -kmer-size {wildcards.ksize} -abundance-min 1 >& {output}.log.txt && rm -f {catlas_base}/bcalm.{catlas_base}.k{wildcards.ksize}.{{h5,unitigs.fa.glue*}}) || printf '**\\n**\\n** Cannot run BCALM 2! Please install it and make sure it is on your path!\\n**\\n**\\n'"
+        "(bcalm -in {input} -out {catlas_base}/bcalm.{catlas_base}.k{wildcards.ksize} -kmer-size {wildcards.ksize} -abundance-min 1 >& {output}.log.txt && rm -f {catlas_base}/bcalm.{catlas_base}.k{wildcards.ksize}.{{h5,unitigs.fa.glue*}}) || printf '**\\n**\\n** Cannot run BCALM 2! Please install it and make sure it is on your path!\\n**\\n**\\n'"
 
 # create list of input files for bcalm
 rule bcalm_cdbg_inpfiles:
      input:
         input_sequences
      output:
-        "bcalm.{catlas_base}.k{ksize}.inputlist.txt"
+        "{catlas_base}/bcalm.{catlas_base}.k{ksize}.inputlist.txt"
      run:
-        with open("bcalm.{catlas_base}.k{ksize}.inputlist.txt".format(catlas_base=catlas_base, ksize=ksize), 'wt') as fp:
+        with open(output[0], 'wt') as fp:
             for name in input_sequences:
                 fp.write('{}\n'.format(name))
 

--- a/spacegraphcats/conf/Snakefile
+++ b/spacegraphcats/conf/Snakefile
@@ -41,7 +41,7 @@ overhead = config.get('overhead', 0.0)
 
 # fix paths to searchquick, search files
 config['search'] = fix_relative_input_paths(config.get('search', []))
-config['searchquick'] = fix_relative_input_paths(config.get('search', []))
+config['searchquick'] = fix_relative_input_paths(config.get('searchqiuck', []))
 
 # paper evaluation: do not expand the cDBG nodes using the domset
 cdbg_only = ""


### PR DESCRIPTION
Usage: `python -m spacegraphcats dory-test search extract_reads extract_contigs --outdir=/tmp`

This will put all of the output files under /tmp/.

Fixes #223.

