### PR TITLE
add the catlas name to the output signature name

### DIFF
--- a/spacegraphcats/search/test_workflow.py
+++ b/spacegraphcats/search/test_workflow.py
@@ -1,6 +1,7 @@
 import os.path
 import shutil
 import screed
+import sourmash
 
 import pytest
 import spacegraphcats.utils.pytest_utils as pytest_utils
@@ -98,6 +99,13 @@ def test_dory_query_workflow(location):
 
         last_line = lines[-1].strip()
         assert last_line == 'dory-head.fa,1.0,1.0,1671,2,21,1631,1.0,0.0,0.0,dory_k21_r1'
+
+    sigfile = output_path + 'dory-head.fa.contigs.sig'
+    with open(sigfile, 'rt') as fp:
+        sig = sourmash.load_one_signature(fp)
+        name = sig.name()
+        assert 'from dory_k21_r1' in name
+        assert name.startswith('nbhd:TRINITY_DN290219_c0_g1_i1')
 
 
 @pytest_utils.in_tempdir


### PR DESCRIPTION
Fixes #263 

After running 
```
% make dory-test
% sourmash sig describe dory_k21_r1_search_oh0/*.sig
```
we now see:
```
...
signature filename: dory_k21_r1_search_oh0//dory-head.fa.contigs.sig
signature: nbhd:TRINITY_DN290219_c0_g1_i1 len=854 path=[1764:0-36 1765:37-60 1767:61-545 1762:546-569 1763:570-853] [-1, 1764, 1765, 1767, 1762, 1763, -2] from dory_k21_r1
...
signature: nbhd:nomatch from dory_k21_r1
source file: random-query-nomatch.fa.contigs.sig
```