### PR TITLE
Update sourmash dep so that environment.yml installs from wheel again

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,4 +16,4 @@ dependencies:
     - bbhash>=0.5.4
     - pip
     - pip:
-      - https://github.com/dib-lab/sourmash/archive/latest.zip
+      - sourmash==4.0.0a3


### PR DESCRIPTION
(Bad Titus, no more relying on unreleased versions of sourmash.)