### PR TITLE
handle duplicate hashes in input cDBG.

### DIFF
--- a/spacegraphcats/cdbg/index_cdbg_by_kmer.py
+++ b/spacegraphcats/cdbg/index_cdbg_by_kmer.py
@@ -139,6 +139,7 @@ class MPHF_KmerIndex(object):
 def build_mphf(ksize, records_iter_fn):
     # build a list of all k-mers in the cDBG
     all_kmers = set()
+    sum_kmers = 0
 
     records_iter = records_iter_fn()
     for n, record in enumerate(records_iter):
@@ -146,10 +147,16 @@ def build_mphf(ksize, records_iter_fn):
             print("... contig", n, end="\r")
 
         kmers = hash_sequence(record.sequence, ksize)
+        sum_kmers += len(kmers)
         all_kmers.update(kmers)
 
     n_contigs = n + 1
     print(f"loaded {n_contigs} contigs.\n")
+
+    if len(all_kmers) != sum_kmers:
+        print('WARNING: likely hash collisions (or duplicate k-mers?) in input cDBG')
+        print('WARNING: we hashed {sum_kmers}, but only {len(all_kmers)} distinct hashes.')
+        print('WARNING: the impact of this on spacegraphcats is unclear, but, at least for now, there\'s nothing you can do about it. Apologies.')
 
     # build MPHF (this is the CPU intensive bit)
     print(f"building MPHF for {len(all_kmers)} k-mers in {n_contigs} nodes.")

--- a/spacegraphcats/cdbg/index_cdbg_by_kmer.py
+++ b/spacegraphcats/cdbg/index_cdbg_by_kmer.py
@@ -155,7 +155,6 @@ def build_mphf(ksize, records_iter_fn):
         seen_before = all_kmers.intersection(these_kmers)
         if seen_before:
             multicounts.update(seen_before)
-            these_kmers -= seen_before
 
         all_kmers.update(these_kmers)
 
@@ -166,6 +165,8 @@ def build_mphf(ksize, records_iter_fn):
         print('NOTE: likely hash collisions (or duplicate k-mers?) in input cDBG')
         print(f'NOTE: {len(multicounts)} k-mer hash values are present more than once.')
         print('NOTE: these k-mers are being removed from consideration.')
+
+        all_kmers -= multicounts
     else:
         print('NOTE: no multicount hashvals detected.')
 

--- a/spacegraphcats/cdbg/index_cdbg_by_kmer.py
+++ b/spacegraphcats/cdbg/index_cdbg_by_kmer.py
@@ -155,7 +155,7 @@ def build_mphf(ksize, records_iter_fn):
 
     if len(all_kmers) != sum_kmers:
         print('WARNING: likely hash collisions (or duplicate k-mers?) in input cDBG')
-        print('WARNING: we hashed {sum_kmers}, but only {len(all_kmers)} distinct hashes.')
+        print(f'WARNING: we hashed {sum_kmers}, but only {len(all_kmers)} distinct hashes.')
         print('WARNING: the impact of this on spacegraphcats is unclear, but, at least for now, there\'s nothing you can do about it. Apologies.')
 
     # build MPHF (this is the CPU intensive bit)


### PR DESCRIPTION
It looks like #369 was caused by new consistency checks in our code that now check that two cDBG unitigs never share k-mer hashes. This could be due to a murmurhash hash collision (which happens, but should happen rarely) or due to a problem in the output cDBG (actual shared k-mers, which would be a bug). In this case, it's a hash collision. How exciting!

This PR addresses the issue by detecting and removing multicount hash values.

The effect of this fix is to simply ignore the (presumably extremely rare) hash values that have collisions. This means that they will present as k-mers missing from the data set. This should have approximately 0 effect on queries.

The impact on speed needs to be measured, as this adds conditionals that might be unfriendly. A better solution might be to implement this over in bbhash where we can take advantage of Cython...

Note that it's not clear bbhash is doing a sensible thing with duplicate hash values. Specifically, when we had dup hashvals in the list, it looks like bbhash did not detect this and would assign them different MPHF values, but only one of the values would be reachable. I need to confirm this behavior over in pybbhash, tho.

TODO:
- [x] verify that this is a duplicate k-mer hash with murmurhash, just 'cause
- [x] implement duplicate k-mer detection and removal
- [x] benchmark it.

Fixes #369.