### PR TITLE
[MRG] support randomizing unitig order via config parameter.

### DIFF
--- a/spacegraphcats/cdbg/sort_bcalm_unitigs.py
+++ b/spacegraphcats/cdbg/sort_bcalm_unitigs.py
@@ -23,12 +23,16 @@ def main(argv):
     parser.add_argument("sqlite_db_out")
     parser.add_argument("mapping_pickle_out")
     parser.add_argument("-k", "--ksize", type=int, default=31)
+    parser.add_argument("--seed", type=int, default=42,
+                        help="minimizer seed for sorting contigs")
     args = parser.parse_args(argv)
 
     unitigs = args.bcalm_unitigs
     ksize = args.ksize
 
-    empty_mh = sourmash.MinHash(n=1, ksize=ksize)
+    # this MinHash is used to find a minimizer for each contig, so that
+    # can sort them deterministically.
+    empty_mh = sourmash.MinHash(n=1, ksize=ksize, seed=args.seed)
 
     ###
     db = sqlite3.connect(args.sqlite_db_out)

--- a/spacegraphcats/conf/Snakefile
+++ b/spacegraphcats/conf/Snakefile
@@ -62,6 +62,9 @@ if config.get('cdbg_only', False):
     cdbg_only = "--cdbg-only"
     catlas_suffix = "_cdbg"
 
+# debugging/evaluation only: shuffle cDBG nodes?
+cdbg_shuffle_seed = config.get('cdbg_shuffle_seed')
+
 # suffix to add to search output
 experiment = config.get('experiment', '')
 search_out_suffix = ''
@@ -185,9 +188,11 @@ rule bcalm_catlas_sort:
     shadow: "shallow"
     params:
         ksize = ksize,
+        seed = cdbg_shuffle_seed if cdbg_shuffle_seed else 42
     shell: """
         python -Werror -m spacegraphcats.cdbg.sort_bcalm_unitigs \
-            -k {params.ksize} {input.unitigs} {output.db} {output.mapping}
+            -k {params.ksize} {input.unitigs} {output.db} {output.mapping} \
+            --seed {params.seed}
      """
 
 # build catlas input from bcalm output by reformatting; optionally,

--- a/spacegraphcats/conf/Snakefile
+++ b/spacegraphcats/conf/Snakefile
@@ -188,7 +188,7 @@ rule bcalm_catlas_sort:
     shadow: "shallow"
     params:
         ksize = ksize,
-        seed = cdbg_shuffle_seed if cdbg_shuffle_seed else 42
+        seed = cdbg_shuffle_seed if cdbg_shuffle_seed is not None else 42
     shell: """
         python -Werror -m spacegraphcats.cdbg.sort_bcalm_unitigs \
             -k {params.ksize} {input.unitigs} {output.db} {output.mapping} \

--- a/tests/test_dory_workflow.py
+++ b/tests/test_dory_workflow.py
@@ -93,6 +93,32 @@ def test_dory_break_bad_bcalm(location):
 
 
 @pytest_utils.in_tempdir
+def test_dory_sort_bcalm_diff_seed(location):
+    from spacegraphcats.cdbg import sort_bcalm_unitigs
+
+    copy_dory_head()
+    copy_dory_subset()
+
+    # make the output directory
+    try:
+        os.mkdir("dory_k21_seedtest")
+    except FileExistsError:
+        pass
+
+    # sort the bcalm file
+    args = [
+        "-k",
+        "21",
+        relative_file("data/bcalm-BROKEN.dory.k21.unitigs.fa"),
+        "dory_k21_seedtest/bcalm.unitigs.db",
+        "dory_k21_seedtest/bcalm.unitigs.pickle",
+        "--seed", "43",
+    ]
+
+    assert sort_bcalm_unitigs.main(args) != 0
+
+
+@pytest_utils.in_tempdir
 def test_dory_query_workflow(location):
     from spacegraphcats.cdbg import bcalm_to_gxt2, sort_bcalm_unitigs
 


### PR DESCRIPTION
This adds a config parameter to randomly re-order the cDBG nodes, `cdbg_shuffle_seed`.

This can be set in the config file like so:

```yaml
cdbg_shuffle_seed: 42
```
The default is `42`, which is tied to the default seed parameter in sourmash `MinHash` objects.