### PR TITLE
[MRG] update sourmash version requirements to >=4.1,<5

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,4 +14,4 @@ dependencies:
     - click=7.1.2
     - pyflakes
     - bbhash>=0.5.4
-    - sourmash>=4,<5
+    - sourmash>=4.1,<5

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click == 7.1.2
 sortedcontainers
 bbhash >= 0.5
 https://github.com/dib-lab/khmer/archive/master.zip
-sourmash>3.4.1,<4
+sourmash>=4.1,<5
 flake8
 black
 pre-commit


### PR DESCRIPTION
This updates both `requirements.txt` and `environment.yml` to use the latest released version of sourmash.

Fixes https://github.com/spacegraphcats/spacegraphcats/issues/336