### PR TITLE
[MRG] update Snakefile with `contigs.sizes` in a rule output

### DIFF
--- a/spacegraphcats/conf/Snakefile
+++ b/spacegraphcats/conf/Snakefile
@@ -279,6 +279,7 @@ rule make_contigs_kmer_index:
     output:
         f"{catlas_dir}/contigs.mphf",
         f"{catlas_dir}/contigs.indices",
+        f"{catlas_dir}/contigs.sizes",
     shadow: "shallow"
     params:
         ksize = ksize,


### PR DESCRIPTION
Over in https://github.com/spacegraphcats/spacegraphcats/pull/392, @taylorreiter subtly pointed out to me that our `Snakefile` did not properly indicate where `contigs.sizes` came from. This PR updates that to make it clear that it comes from `spacegraphcats.cdbg.index_cdbg_by_kmer` in rule `make_contigs_kmer_index`.
