### PR TITLE
[MRG] store ksize in MPHF index save files

### DIFF
--- a/spacegraphcats/cdbg/hashing.py
+++ b/spacegraphcats/cdbg/hashing.py
@@ -20,12 +20,13 @@ def hash_sequence(seq, ksize):
     return hashing_fn(seq)
 
 
-class MPHF_KmerIndex(object):
+class MPHF_KmerIndex:
     """
     Support kmer -> cDBG node id queries.
     """
 
-    def __init__(self, bbhash_table, sizes):
+    def __init__(self, ksize, bbhash_table, sizes):
+        self.ksize = ksize
         self.table = bbhash_table
         self.sizes = sizes
 
@@ -105,17 +106,25 @@ class MPHF_KmerIndex(object):
 
         return dom_matches
 
+    def save(self, location):
+        "Save kmer index."
+        mphf_filename = os.path.join(location, "contigs.mphf")
+        array_filename = os.path.join(location, "contigs.indices")
+        sizes_filename = os.path.join(location, "contigs.sizes")
+
+        self.table.save(mphf_filename, array_filename)
+        with open(sizes_filename, "wb") as fp:
+            pickle.dump((self.ksize, self.sizes), fp)
+
     @classmethod
     def from_catlas_directory(cls, catlas_prefix):
-        "Load kmer index created by search.contigs_by_kmer."
+        "Load kmer index created by search.index_cdbg_by_kmer."
         mphf_filename = os.path.join(catlas_prefix, "contigs.mphf")
         array_filename = os.path.join(catlas_prefix, "contigs.indices")
         sizes_filename = os.path.join(catlas_prefix, "contigs.sizes")
 
         table = BBHashTable.load(mphf_filename, array_filename)
         with open(sizes_filename, "rb") as fp:
-            sizes = pickle.load(fp)
+            ksize, sizes = pickle.load(fp)
 
-        return cls(table, sizes)
-
-
+        return cls(ksize, table, sizes)

--- a/spacegraphcats/cdbg/index_reads.py
+++ b/spacegraphcats/cdbg/index_reads.py
@@ -76,6 +76,7 @@ def main(argv=sys.argv[1:]):
     # load k-mer MPHF index: { kmers -> cDBG IDs }
     ki_start = time.time()
     kmer_idx = MPHF_KmerIndex.from_catlas_directory(args.catlas_prefix)
+    assert args.ksize == kmer_idx.ksize
     notify("loaded {} k-mers in index ({:.1f}s)", len(kmer_idx), time.time() - ki_start)
 
     total_bp = 0

--- a/spacegraphcats/search/index_cdbg_by_multifasta.py
+++ b/spacegraphcats/search/index_cdbg_by_multifasta.py
@@ -55,6 +55,7 @@ def main(argv):
     # ...and kmer index.
     ki_start = time.time()
     kmer_idx = MPHF_KmerIndex.from_catlas_directory(args.catlas_prefix)
+    assert args.ksize == kmer_idx.ksize
     notify("loaded {} k-mers in index ({:.1f}s)", len(kmer_idx), time.time() - ki_start)
 
     # calculate the k-mer sizes for each catlas node.

--- a/spacegraphcats/search/query_by_sequence.py
+++ b/spacegraphcats/search/query_by_sequence.py
@@ -324,6 +324,7 @@ def main(argv):
     # ...and kmer index.
     ki_start = time.time()
     kmer_idx = MPHF_KmerIndex.from_catlas_directory(args.catlas_prefix)
+    assert args.ksize == kmer_idx.ksize
     notify("loaded {} k-mers in index ({:.1f}s)", len(kmer_idx), time.time() - ki_start)
 
     # ...and contigs db


### PR DESCRIPTION
Adds a `.ksize` attribute to `MPHF_KmerIndex` objects, and checks that this matches the requested ksize in various scripts.

Fixes https://github.com/spacegraphcats/spacegraphcats/issues/320

**Note:** this PR changes save formats and will require rerunning build (or patch-fixing `contigs.sizes`).

