### PR TITLE
[MRG] add `defaults.conf`; update docs to specify YAML instead of JSON

### DIFF
--- a/doc/01-running-spacegraphcats.md
+++ b/doc/01-running-spacegraphcats.md
@@ -194,9 +194,9 @@ query, and the reads for the neighborhoods around each query.
 The `spacegraphcats` script has several targets, in addition to `search`.
 
 * `python -m spacegraphcats run twofoo build` will build the catlas
-* `python -m spacegraphcats twofoo clean` should remove the build targets.
-* `python -m spacegraphcats twofoo extract_contigs` -- get contigs for search results; see above.
-* `python -m spacegraphcats twofoo extract_reads` -- get reads for search results; see above.
+* `python -m spacegraphcats run twofoo clean` should remove the build targets.
+* `python -m spacegraphcats run twofoo extract_contigs` -- get contigs for search results; see above.
+* `python -m spacegraphcats run twofoo extract_reads` -- get reads for search results; see above.
 
 You can also specify `--radius <n>` to override the radius defined in the YAML config file and `--experiment foo` to append a `_foo` to the search directory.)
 

--- a/doc/01-running-spacegraphcats.md
+++ b/doc/01-running-spacegraphcats.md
@@ -7,7 +7,7 @@ Please see [Installing spacegraphcats](00-installing-spacegraphcats.md).
 ## Running spacegraphcats search & output files
 
 ```
-python -m spacegraphcats dory-test search
+python -m spacegraphcats run dory-test search
 ```
 
 This should run in a few seconds, and you should see something like this in the output:
@@ -128,7 +128,7 @@ which will take a few minutes.
 
 Then, run:
 ```
-python -m spacegraphcats twofoo search
+python -m spacegraphcats run twofoo search
 ```
 
 which will generate searches of the twofoo synthetic data set with `data/2.fa.gz`, `data/47.fa.gz`, and `data/63.fa.gz`.
@@ -170,7 +170,7 @@ corresponding to them, by using the targets `extract_reads` and
 `extract_contigs`.
 
 ```
-python -m spacegraphcats twofoo extract_contigs extract_reads
+python -m spacegraphcats run twofoo extract_contigs extract_reads
 ```
 
 This will produce the files:
@@ -211,7 +211,7 @@ Last, but not least: snakemake locks the directory to make sure processes don't 
 First, build the twofoo data set with r5:
 
 ```
-python -m spacegraphcats twofoo build --radius=5
+python -m spacegraphcats run twofoo build --radius=5
 ```
 
 Then, extract nodes with many cDBG nodes and few k-mers (by ratio):

--- a/doc/01-running-spacegraphcats.md
+++ b/doc/01-running-spacegraphcats.md
@@ -193,7 +193,7 @@ query, and the reads for the neighborhoods around each query.
 
 The `spacegraphcats` script has several targets, in addition to `search`.
 
-* `python -m spacegraphcats twofoo build` will build the catlas
+* `python -m spacegraphcats run twofoo build` will build the catlas
 * `python -m spacegraphcats twofoo clean` should remove the build targets.
 * `python -m spacegraphcats twofoo extract_contigs` -- get contigs for search results; see above.
 * `python -m spacegraphcats twofoo extract_reads` -- get reads for search results; see above.

--- a/doc/01-running-spacegraphcats.md
+++ b/doc/01-running-spacegraphcats.md
@@ -67,9 +67,9 @@ There are three important top-level files.
 
 1. The script `python -m spacegraphcats` uses [snakemake](https://snakemake.readthedocs.io/en/stable/) to run the pipeline.
 
-2. The Snakefile itself is under `conf/Snakefile`, and is not intended to be particularly human readable :). The snakemake run is configured by a JSON config file.
+2. The Snakefile itself is under `conf/Snakefile`, and is not intended to be particularly human readable :). The snakemake run is configured by a [YAML config file](https://www.cloudbees.com/blog/yaml-tutorial-everything-you-need-get-started/).
 
-3. The configuration files are relatively simple, and are (by convention) contained in the `conf/` directory, although you can put them elsewhere.
+3. The configuration files are relatively simple, and are (by convention) contained in the `conf/` directory, although you can put them elsewhere. The filenames should end in either `.yaml` or `.conf`.
 
 To run spacegraphcats on a new data set, you will need to write a new config file.
 
@@ -77,45 +77,42 @@ To run spacegraphcats on a new data set, you will need to write a new config fil
 
 Config files look like this:
 ```
-{
-    "catlas_base": "dory",
-    "input_sequences": ["data/dory-subset.fa"],
-    "ksize": 21,
-    "radius": 1,
-
-    "searchquick": ['data/dory-head.fa'],
-    "searchseeds": "43",
-    "search": ['data/dory-head.fa'],
-}
+catlas_base: dory
+input_sequences:
+- data/dory-subset.fq
+keep_graph_pendants: true
+paired_reads: false
+ksize: 21
+radius: 1
+search:
+- data/dory-head.fa
 ```
 
 Here, the `catlas_base`, `ksize`, and `radius` are used to name output directories - hence `dory/` and `dory_k21_r1/`, above. `catlas_base` is arbitrary, `ksize` is the k-mer size (we suggest 21 or 31), and `radius` is the domset radius (we suggest 1).
 
 The `input_sequences` contains the set of input files (FASTA or FASTQ, potentially gzipped) to use to build the compact De Bruijn graph. Note, these should be k-mer-error-trimmed, or otherwise you will have very big cDBGs... see [the error trimming information from Brown et al. for an example](https://github.com/spacegraphcats/2018-paper-spacegraphcats/tree/master/pipeline-base#pipeline-to-generate-files-needed-for-figures-2-and-3). Note that the `trim-low-abund.py` command is in the khmer package, which is a requirement for spacegraphcats, so you will already have it installed.
 
-The `searchquick` and `search` specify the *query files* that you are using to search the catlas.
+The `search` entry specifies the *query files* that you are using to search the catlas.
 
 So, in brief, this config file:
 
 * builds a catlas with k=21 and r=1 from `data/dory-subset.fa`;
-* searches with `data/dory-head.fa` when you call either `search` or `searchquick`.
+* searches with `data/dory-head.fa` when you call `search`.
 
 ## A larger example: `twofoo`
 
 Here you can see another config file, for a synthetic mixture
 of two genomes (Akkermansia and Shewanella baltica OS 223) from the Shakya et al., 2014, benchmark study:
 ```
-{
-    "catlas_base": "twofoo",
-    "input_sequences": ["twofoo.fq.gz"],
-    "ksize": 31,
-    "radius": 1,
-
-    "searchquick": ["data/63.fa.gz"],
-
-    "search": ["data/2.fa.gz", "data/47.fa.gz", "data/63.fa.gz"],
-
-}
+catlas_base: twofoo
+input_sequences:
+- twofoo.fq.gz
+ksize: 31
+radius: 1
+search:
+- data/2.fa.gz
+- data/47.fa.gz
+- data/63.fa.gz
 ```
 
 To run this, you'll first need to download and prepare the input file, `twofoo.fq.gz`:
@@ -191,14 +188,14 @@ query, and the reads for the neighborhoods around each query.
 
 ### The `spacegraphcats` script
 
-The `spacegraphcats` script has several targets, in addition to `search` and `searchquick`.
+The `spacegraphcats` script has several targets, in addition to `search`.
 
 * `python -m spacegraphcats twofoo build` will build the catlas
 * `python -m spacegraphcats twofoo clean` should remove the build targets.
 * `python -m spacegraphcats twofoo extract_contigs` -- get contigs for search results; see above.
 * `python -m spacegraphcats twofoo extract_reads` -- get reads for search results; see above.
 
-You can also specify `--radius <n>` to override the radius defined in the JSON config file; `--overhead <fraction>` to specify an overhead for searches; and `--experiment foo` to append a `_foo` to the search directory.)
+You can also specify `--radius <n>` to override the radius defined in the YAML config file and `--experiment foo` to append a `_foo` to the search directory.)
 
 Last, but not least: snakemake locks the directory to make sure processes don't step on each other. This is important when catlases need to be built (you don't want two different `search` commands stepping on each other during the catlas building phase) but once you have built catlases you can do searches in parallel.  To enable this add `--nolock` to the run command. 
 

--- a/doc/01-running-spacegraphcats.md
+++ b/doc/01-running-spacegraphcats.md
@@ -71,7 +71,10 @@ There are three important top-level files.
 
 3. The configuration files are relatively simple, and are (by convention) contained in the `conf/` directory, although you can put them elsewhere. The filenames should end in either `.yaml` or `.conf`.
 
-To run spacegraphcats on a new data set, you will need to write a new config file.
+To run spacegraphcats on a new data set, you will need to write a new
+config file. An empty template is available as
+`spacegraphcats/conf/empty.yaml`, and you can display the empty config
+file with `python -m spacegraphcats showconf empty`.
 
 ## Config files: the `dory` example
 

--- a/doc/02-spacegraphcats-use-cases.md
+++ b/doc/02-spacegraphcats-use-cases.md
@@ -66,7 +66,6 @@ ksize: 31
 radius: 1
 search:
 - GCA_001508995.1_ASM150899v1_genomic.fna.gz
-searchquick: GCA_001508995.1_ASM150899v1_genomic.fna.gz
 ```
 
 run spacegraphcats:
@@ -233,7 +232,6 @@ ksize: 31
 radius: 1
 search:
 - outputs/arg90_matches/cfxA4_AY769933.fna
-searchquick: outputs/arg90_matches/cfxA4_AY769933.fna
 ```
 
 Run spacegraphcats to extract the sequence context around the antibiotic resistance gene.

--- a/doc/06-snakemake-spacegraphcats.md
+++ b/doc/06-snakemake-spacegraphcats.md
@@ -57,8 +57,7 @@ for sample in SAMPLES:
            'input_sequences': ['outputs/abundtrim/' + sample + '.abundtrim.fq.gz'],
            'ksize': 31, 
            'radius': 1,
-           'search': genome_query_paths,
-           'searchquick': genome_query_paths[0]}
+           'search': genome_query_paths}
     with io.open("inputs/sgc_conf/" + sample + '_r1_conf.yml', 'w', encoding='utf8') as outfile:
         yaml.dump(yml, outfile, default_flow_style=False, allow_unicode=True, sort_keys=False)
 ```

--- a/spacegraphcats/__main__.py
+++ b/spacegraphcats/__main__.py
@@ -49,7 +49,6 @@ def run_snakemake(
 
     configfiles = [
         get_package_configfile("defaults.conf"),
-        get_package_configfile("system.conf")
     ]
     # add user=specified configfile - try looking for it a few different ways.
     if os.path.isfile(configfile):
@@ -68,7 +67,7 @@ def run_snakemake(
                 configfiles.append(tryfile)
                 break
 
-    if len(configfiles) == 2:
+    if len(configfiles) == 1:
         raise ValueError(f"cannot find config file '{configfile}'")
 
     cmd += ["--configfile"] + configfiles

--- a/spacegraphcats/__main__.py
+++ b/spacegraphcats/__main__.py
@@ -47,25 +47,28 @@ def run_snakemake(
     # add rest of snakemake arguments
     cmd += list(extra_args)
 
-    # add configfile - try looking for it a few different ways.
-    configfiles = []
+    configfiles = [
+        get_package_configfile("defaults.conf"),
+        get_package_configfile("system.conf")
+    ]
+    # add user=specified configfile - try looking for it a few different ways.
     if os.path.isfile(configfile):
-        configfiles = [configfile]
+        configfiles.append(configfile)
     elif os.path.isfile(get_package_configfile(configfile)):
-        configfiles = [get_package_configfile(configfile)]
+        configfiles.append(get_package_configfile(configfile))
     else:
         for suffix in ".yaml", ".conf":
             tryfile = configfile + suffix
             if os.path.isfile(tryfile):
-                configfiles = [tryfile]
+                configfiles.append(tryfile)
                 break
 
             tryfile = get_package_configfile(tryfile)
             if os.path.isfile(tryfile):
-                configfiles = [tryfile]
+                configfiles.append(tryfile)
                 break
 
-    if not configfiles:
+    if len(configfiles) == 2:
         raise ValueError(f"cannot find config file '{configfile}'")
 
     cmd += ["--configfile"] + configfiles

--- a/spacegraphcats/conf/Snakefile
+++ b/spacegraphcats/conf/Snakefile
@@ -39,6 +39,10 @@ def fix_relative_input_paths(filenames):
 
 # name of catlas
 catlas_base = config['catlas_base']
+if not catlas_base:
+    print("config parameter 'catlas_base' must be non-empty.",
+          file=sys.stderr)
+    sys.exit(-1)
 
 # sequence files to use when building catlas
 input_sequences = fix_relative_input_paths(config['input_sequences'])
@@ -48,9 +52,6 @@ ksize = config['ksize']
 
 # radius for catlas building
 radius = config['radius']
-
-# search overhead
-overhead = config.get('overhead', 0.0)
 
 # fix paths to search files
 config['search'] = fix_relative_input_paths(config.get('search', []))
@@ -97,7 +98,7 @@ multifasta_query_sig = fix_relative_input_paths([multifasta_query_sig])[0]
 
 cdbg_dir = f'{catlas_base}_k{ksize}'
 catlas_dir = f'{catlas_base}_k{ksize}_r{radius}{catlas_suffix}'
-search_dir = f'{catlas_dir}_search_oh{int(overhead*100)}{search_out_suffix}'
+search_dir = f'{catlas_dir}_search_oh0{search_out_suffix}'
 
 hashval_ksize = config.get('hashval_ksize', ksize)
 hashval_query_dir = f'{catlas_dir}_hashval_k{hashval_ksize}'

--- a/spacegraphcats/conf/defaults.conf
+++ b/spacegraphcats/conf/defaults.conf
@@ -1,3 +1,33 @@
+# parent directory for output; defaults to current directory.
+outdir: ''
+
+# name of foo, must be set
+catlas_base: ''
+
+# list of search genomes
+search: []
+
+# suffix to be added for tracking different 'experiment' runs
+experiment: ''
+
+# some decent defaults
 paired_reads: false
+keep_graph_pendants: false
 ksize: 31
 radius: 1
+
+# misc advanced stuff, see docs
+#hashval_queries: ''
+#hasval_ksize: 31
+#multifasta_reference: []
+#multifasta_query_sig: ''
+#multifasta_scaled: 1000
+#shadow_ratio_maxsize: 1000
+
+# not really used yet:
+# decompose_minsize 5000
+# decompose_maxsize: 50000
+
+# debugging/benchmarking parameters:
+#cdbg_only: false
+#cdbg_shuffle_seed: 42

--- a/spacegraphcats/conf/defaults.conf
+++ b/spacegraphcats/conf/defaults.conf
@@ -1,0 +1,3 @@
+paired_reads: false
+ksize: 31
+radius: 1

--- a/spacegraphcats/conf/empty.yaml
+++ b/spacegraphcats/conf/empty.yaml
@@ -1,0 +1,6 @@
+catlas_base: dory
+input_sequences:
+- data/dory-subset.fq
+search:
+- data/dory-head.fa
+- data/random-query-nomatch.fa

--- a/spacegraphcats/conf/system.conf
+++ b/spacegraphcats/conf/system.conf
@@ -1,0 +1,2 @@
+# can't have empty config file!
+paired_reads: false

--- a/spacegraphcats/conf/system.conf
+++ b/spacegraphcats/conf/system.conf
@@ -1,2 +1,0 @@
-# can't have empty config file!
-paired_reads: false


### PR DESCRIPTION
This PR adds a `defaults.conf` and updates the docs in a few ways.

Goals:
* make it so that `showconf` target actually shows _all_ of the config options, not just the ones set in the config file
* provide reasonable (or empty) defaults, provide good error messages when required parameters are not set.