### PR TITLE
[ MRG] fix command typo in documentation

### DIFF
--- a/doc/05-alpha-spacegraphcats.md
+++ b/doc/05-alpha-spacegraphcats.md
@@ -50,7 +50,7 @@ Where the `multifasta_reference` contains the gene in a query of interest, `mult
 Then, run spacegraphcats:
 
 ```
-python -m spacegraphcats twofoo multifasta_query
+python -m spacegraphcats run twofoo multifasta_query
 ```
 
 ## graphgrep


### PR DESCRIPTION
adds `run` to a command in docs
