### PR TITLE
[MRG] add cdbg node annotations to multifasta query output

### DIFF
--- a/spacegraphcats/conf/Snakefile
+++ b/spacegraphcats/conf/Snakefile
@@ -552,11 +552,12 @@ rule build_cdbg_list_by_record:
         multi_idx = f"{catlas_dir}_multifasta/multifasta.pickle",
         info_csv = f"{cdbg_dir}/contigs.info.csv",
     output:
-        f"{catlas_dir}_multifasta/multifasta.cdbg_by_record.csv",
+        cdbg_record = f"{catlas_dir}_multifasta/multifasta.cdbg_by_record.csv",
+        cdbg_annot = f"{catlas_dir}_multifasta/multifasta.cdbg_annot.csv",
     shell: """
         python -Werror -m spacegraphcats.search.extract_cdbg_by_multifasta \
-            --multi-idx {input.multi_idx} --output {output} \
-            --info-csv {input.info_csv}
+            --multi-idx {input.multi_idx} --output-cdbg-record {output.cdbg_record} \
+            --output-cdbg-annot {output.cdbg_annot} --info-csv {input.info_csv}
     """
 
 # get reads for a single multifasta record

--- a/tests/test_dory_workflow.py
+++ b/tests/test_dory_workflow.py
@@ -739,10 +739,11 @@ def test_dory_multifasta_query(location):
     args = "--hashvals dory_k21_r1_multifasta/hashval.pickle --multi-idx dory_k21_r1_multifasta/multifasta.pickle  --query-sig dory-subset.fq.sig --output dory_k21_r1_multifasta/query-results.csv -k 21 --scaled 100"
     assert query_multifasta_by_sig.main(args.split()) == 0
 
-    args = "--multi-idx dory_k21_r1_multifasta/multifasta.pickle --output dory_k21_r1_multifasta/multifasta.cdbg_by_record.csv --info-csv dory_k21/contigs.info.csv"
+    args = "--multi-idx dory_k21_r1_multifasta/multifasta.pickle --output-cdbg-record dory_k21_r1_multifasta/multifasta.cdbg_by_record.csv --output-cdbg-annot dory_k21_r1_multifasta/multifasta.cdbg_annot.csv --info-csv dory_k21/contigs.info.csv"
     assert extract_cdbg_by_multifasta.main(args.split()) == 0
 
     assert os.path.exists("dory_k21_r1_multifasta/multifasta.cdbg_by_record.csv")
+    assert os.path.exists("dory_k21_r1_multifasta/multifasta.cdbg_annot.csv")
     assert os.path.exists("dory_k21_r1_multifasta/query-results.csv")
 
 


### PR DESCRIPTION
Addresses #420. I wanted a file that has the cdbg id mapped to the annotation that contains sequences in its nbhd.

Not sure if the naming scheme is sufficient, it was clear to me. 

I went for adding a separate file instead of combining all into one csv. Don't really care either way. 

@ctb ready for review and merge