### PR TITLE
Fix sanity check in rdomset.domination_graph()

### DIFF
--- a/spacegraphcats/catlas/rdomset.py
+++ b/spacegraphcats/catlas/rdomset.py
@@ -294,8 +294,8 @@ def domination_graph(graph: Graph, domset: Set[int], radius: int):
                     q.append((s, w, d + 1))
 
     # Sanity-check
-    for v, value in enumerate(assigned_dominator):
-        assert value >= 0
+    for v, value in assigned_dominator.items():
+        assert value >= 0, 'not assigned: v={}'.format(v)
 
     # Compute domgraph edges
     print("computing domgraph edges")

--- a/tests/test_rdomset.py
+++ b/tests/test_rdomset.py
@@ -119,9 +119,12 @@ class ParserRDomset(unittest.TestCase):
         self.assertEqual(set(domgraph.arcs(1)), set([(2, 5), (2, 6), (5, 2), (5, 6), (6, 2), (6, 5)]))
 
         # error cases (should raise an error when the given vertex set is not an r-dominating set)
-        self.assertRaises(AssertionError, lambda: domination_graph(g, [], r))
-        self.assertRaises(AssertionError, lambda: domination_graph(g, [0], r))
-        self.assertRaises(AssertionError, lambda: domination_graph(g, [0, 5, 6, 7, 9], r))
+        self.assertRaises(AssertionError, domination_graph, g, [], r)
+        self.assertRaises(AssertionError, domination_graph, g, [0], r)
+        self.assertRaises(AssertionError, domination_graph, g, [0, 5, 6, 7, 9], r)
+
+        g2 = Graph(num_nodes=10, radius=r)  # isolated vertices
+        self.assertRaises(AssertionError, domination_graph, g2, [0, 1], r)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #423

This PR fixes behavior when the function `rdomset.domination_graph()` is directly called with a vertex set that is not an r-dominating set. It does not require a rebuild of catlas.

