### PR TITLE
[WIP] add GFA parsing scripts and explore working with bifrost

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
     - defaults
 dependencies:
     - bcalm=2.2.3
+    - bifrost=1.0.5
     - snakemake-minimal=6.4.0
     - screed>=1.0.5,<2
     - khmer=3.0.0a3

--- a/scripts/convertToGFA.py
+++ b/scripts/convertToGFA.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+
+'''****************************************************************************
+
+*   Program - Convert To GFA format
+*   Author - Mayank Pahadia
+
+
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+
+****************************************************************************'''
+
+'''****************************************************************************
+
+*   To run the program, pass three arguments with the python script on command line.
+*   For example - python convertToGFA.py inputFileName outputFileName kmerSize
+
+*   Logic - It reads through the fasta file with all the unitigs information 
+*   and link information and outputs it in the GFA format. 
+
+
+****************************************************************************'''
+
+
+import sys
+import argparse
+
+def write_segment(name,segment,optional,g,links):
+    add = ""
+    add += "S\t" #for segment
+    add += name #id of segment
+    add += "\t"
+    add += segment #segment itself
+    add += "\t"
+    for i in optional: #optional tags
+        add+=i
+        add+="\t"
+    #adding Segment to the file
+    g.write(add.strip()+"\n")
+    for j in links: #adding all the links of the current segment to the GFA file
+        g.write(j)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert a bcalm-generated FASTA to a GFA.",
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('inputFilename', help='Input FASTA file')
+    parser.add_argument('outputFilename', help='Output GFA file')
+    parser.add_argument('kmerSize', type=int, help='k-mer length')
+    parser.add_argument('-s', '--single-directed', action='store_true',
+                        help='Avoid outputting the whole skew-simmetric graph and output only one edge between two nodes',
+                        dest='single_directed')
+
+    args = parser.parse_args()
+
+    with open(args.inputFilename) as f:
+        #name stores the id of the unitig
+        #optional is a list which stores all the optional tags of a segment
+        #links stores all the link information about a segment
+        name = ""
+        optional=[]
+        links=[]
+        g = open(args.outputFilename,'w')
+        #adding Header to the file
+        k = int(args.kmerSize)
+        g.write('H\tVN:Z:1.0\tks:i:%d\n' %k) # includes the k-mer size
+        print("GFA file open")
+        #firstLine is for implemetation purpose so that we don't add some garbage value to the output file.
+        firstLine = 0
+        #segment stores the segment till present, in a fasta file, segment can be on many lines, hence we need to get the whole segment from all the lines
+        segment = ""
+        for line in f:
+            line = line.replace("\n","")
+            if(line[0]!=">"):
+                #segment might be in more than one line, hence we get the whole segment first, and then put it in the GFA file.
+                segment += line
+            if(line[0]==">"):
+                if(firstLine!=0):#if it's not the firstline in the input file, we store the input in GFA format in the output file
+                    write_segment(name,segment,optional,g,links)
+                    segment = ""
+
+                firstLine = 1
+                #once the previous segment and it's information has been stored, we start the next segment and it's information
+                a = line.split(" ")
+                name=a[0][1:] #get the id
+                optional=[]
+                links = []
+                #we skip the first value because the first value is ">ID"
+                for i in range(1,len(a)):
+                    #we need this because the line can end with a space, hence we get one extra value in our list.
+                    if(a[i]==""):
+                        continue
+                    if(a[i][0:2] == "MA"): #previous bcalm2 versions had "MA=[xxx]" optional tag as well, kept it just for compatibility, and reformated
+                        optional.append(a[i][0:2]+":f:"+a[i][2:])
+                    elif(a[i][0:2] == "L:"): #for links
+                        b = a[i].split(":")
+                        k1 = int(args.kmerSize)-1
+                        if args.single_directed:
+                            if name < b[2]:
+                                links.append("L\t"+name+"\t"+b[1]+"\t"+b[2]+"\t"+b[3]+"\t"+str(k1)+"M\n")
+                            elif name == b[2] and not (b[1] == b[3] == '-'): # manage links between the same unitig
+                                links.append("L\t"+name+"\t"+b[1]+"\t"+b[2]+"\t"+b[3]+"\t"+str(k1)+"M\n")
+                        else:
+                            links.append("L\t"+name+"\t"+b[1]+"\t"+b[2]+"\t"+b[3]+"\t"+str(k1)+"M\n")
+                    else: #all the other optional tags
+                        optional.append(a[i])
+
+
+        #we will miss the last one, because it won't go into the if condition - if(line[0]==">") and hence won't add the segment to the file.
+        write_segment(name,segment,optional,g,links)
+        print("done")
+        g.close()
+
+if __name__ == "__main__":
+    main()

--- a/spacegraphcats/cdbg/bcalm_to_gxt.py
+++ b/spacegraphcats/cdbg/bcalm_to_gxt.py
@@ -202,7 +202,6 @@ class SqliteAsDict:
 
 def main(argv):
     parser = argparse.ArgumentParser()
-    parser.add_argument("bcalm_unitigs")
     parser.add_argument("sqlite_db")
     parser.add_argument("mapping_pickle")
     parser.add_argument("gxt_out")

--- a/spacegraphcats/cdbg/hashing.py
+++ b/spacegraphcats/cdbg/hashing.py
@@ -4,7 +4,7 @@ Hashing code for k-mers -> hash values.
 import os
 import pickle
 
-import khmer
+import sourmash
 from bbhash_table import BBHashTable
 
 hashing_fn = None
@@ -12,10 +12,13 @@ hashing_ksize = None
 
 
 def hash_sequence(seq, ksize):
+    "Hash the given sequence at the given ksize."
     global hashing_fn, hashing_ksize
+
+    # initialize the hashing function, if needed.
     if hashing_fn is None or hashing_ksize != ksize:
-        kh = khmer.Nodetable(ksize, 1, 1)
-        hashing_fn, hashing_ksize = kh.get_kmer_hashes, ksize
+        mh = sourmash.MinHash(n=0, ksize=ksize, scaled=1)
+        hashing_fn, hashing_ksize = mh.seq_to_hashes, ksize
 
     return hashing_fn(seq)
 

--- a/spacegraphcats/cdbg/sort_gfa_unitigs.py
+++ b/spacegraphcats/cdbg/sort_gfa_unitigs.py
@@ -1,0 +1,194 @@
+#! /usr/bin/env python
+"""
+Sort the bcalm unitigs.fa output (a cDBG) into deterministic order.
+Produces output consumed by `bcalm_to_gxt`.
+
+Also saves all of the graph information for later perusal.
+
+Also outputs a sourmash scaled=1000 signature for the input unitigs.
+"""
+import sys
+import argparse
+import pickle
+import collections
+import sqlite3
+
+import sourmash
+from spacegraphcats.search.search_utils import my_fasta_iter
+
+
+def main(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("gfa_unitigs")
+    parser.add_argument("sqlite_db_out")
+    parser.add_argument("mapping_pickle_out")
+    parser.add_argument("-k", "--ksize", type=int, default=31)
+    parser.add_argument("--seed", type=int, default=42,
+                        help="minimizer seed for sorting contigs")
+    args = parser.parse_args(argv)
+
+    unitigs = args.gfa_unitigs
+    ksize = args.ksize
+
+    # this MinHash is used to find a minimizer for each contig, so that
+    # can sort them deterministically.
+    empty_mh = sourmash.MinHash(n=1, ksize=ksize, seed=args.seed)
+
+    ###
+    db = sqlite3.connect(args.sqlite_db_out)
+    cursor = db.cursor()
+    cursor.execute("PRAGMA synchronous='OFF'")
+    cursor.execute("PRAGMA locking_mode=EXCLUSIVE")
+    cursor.execute(
+        "CREATE TABLE sequences (id INTEGER, sequence TEXT, offset INTEGER PRIMARY KEY, min_hashval TEXT, abund FLOAT)"
+    )
+
+    # read & find minimum hash:
+    total_bp = 0
+    neighbors = collections.defaultdict(set)
+
+    # record input k-mers in a minhash
+    in_mh = sourmash.MinHash(0, ksize, scaled=1000)
+
+    print(f"loading GFA unitigs from {unitigs}...")
+
+    unitigs_fp = open(unitigs, "rt")
+
+    def iter_lines_and_pos(fp):
+        pos = fp.tell()
+        line = fp.readline()
+        while line:
+            yield line, pos
+            pos = fp.tell()
+            line = fp.readline()
+    
+    last_pos = 0
+    for n, (line, offset) in enumerate(iter_lines_and_pos(unitigs_fp)):
+        if n % 10000 == 0:
+            print(f"... {n}", end="\r")
+            sys.stdout.flush()
+
+        if line[0] != 'S':
+            continue
+
+        _, name, sequence = line.strip().split('\t')
+
+        total_bp += len(sequence)
+
+        # first, get unitig ID
+        contig_id = int(name)
+
+        # second, track the various links
+        #@CTB links = [x for x in name_split[1:] if x.startswith("L:")]
+        links = []
+        neighbors[contig_id] = links
+
+        # third, get mean abund
+        if 0:
+            abund = [x for x in name_split[1:] if x.startswith("km:")]
+            assert len(abund) == 1, abund
+            abund = abund[0].split(":")
+            assert len(abund) == 3
+            abund = float(abund[2])
+        abund = 0.0
+
+        # fourth, get the min hash val for this sequence
+        mh = empty_mh.copy_and_clear()
+        mh.add_sequence(sequence)
+        assert len(mh) == 1, (len(mh), sequence)
+        min_hashval = next(iter(mh.hashes))
+
+        # fifth, record input k-mers to a bulk signature
+        in_mh.add_sequence(sequence)
+
+        # add to database
+        cursor.execute(
+            "INSERT INTO sequences (id, sequence, offset, min_hashval, abund) VALUES (?, ?, ?, ?, ?)",
+            (contig_id, sequence, offset, str(min_hashval), abund),
+        )
+
+    db.commit()
+
+    unitigs_fp.close()
+
+    print(f"...read {len(neighbors)} unitigs, {total_bp:.2e} bp.")
+    sys.stdout.flush()
+
+    cursor.execute("CREATE UNIQUE INDEX sequence_min_val ON sequences (min_hashval)")
+    cursor.execute("CREATE UNIQUE INDEX offset_idx ON sequences (offset)")
+
+    # sort contigs based on min_hashval!
+    print("remapping cDBG IDs...")
+
+    # remap everything into new coordinate space based on min_hashval ordering
+    remapping = {}
+    cursor.execute("SELECT id, offset FROM sequences ORDER BY min_hashval")
+    for new_key, (old_key, offset,) in enumerate(cursor):
+        remapping[old_key] = new_key
+
+    # remap sequence IDs using offset as unique key
+    cursor.execute("SELECT offset FROM sequences ORDER BY min_hashval")
+    c2 = db.cursor()
+    for new_key, (offset,) in enumerate(cursor):
+        c2.execute("UPDATE sequences SET id=? WHERE offset=?", (new_key, offset))
+        assert c2.rowcount == 1
+
+    cursor.execute("CREATE UNIQUE INDEX sequence_idx ON sequences (id)")
+
+    db.commit()
+
+    print(f"DONE remapping {len(remapping)} contigs.")
+    sys.stdout.flush()
+
+    # parse link structure, map to new IDs.
+    print(f"Remapping {len(neighbors)} neighbors...")
+    new_neighbors = {}
+    total_n = 0
+    for old_key, links in neighbors.items():
+        new_key = remapping[old_key]
+        link_ids = set()
+        for x in links:
+            link_id = int(x.split(":")[2])
+            if link_id != old_key:  # neighbors != self!
+                new_link_id = remapping[link_id]
+                link_ids.add(new_link_id)
+
+        # allow isolated nodes - link_ids can be empty.
+        new_neighbors[new_key] = link_ids
+        total_n += len(link_ids)
+
+    print(f"...done! {total_n} neighbor relationships.")
+    sys.stdout.flush()
+
+    # check links -- make sure that source is always in its neighbors edges.
+    # (this is a check for a recurring bcalm bug that has to do with some
+    # kind of threading problem)
+
+    print("validating link structure...")
+    fail = False
+    for source in new_neighbors:
+        for nbh in new_neighbors[source]:
+            if source not in new_neighbors[nbh]:
+                print(f"{source} -> {nbh}, but not {nbh} -> {source}")
+                fail = True
+    print("...done!")
+    sys.stdout.flush()
+
+    if fail:
+        return -1
+
+    ## save!
+    print(f"saving mappings to '{args.mapping_pickle_out}'")
+    with open(args.mapping_pickle_out, "wb") as fp:
+        pickle.dump((ksize, new_neighbors), fp)
+
+    # output sourmash signature for input contigs
+    in_sig = sourmash.SourmashSignature(in_mh, filename=args.gfa_unitigs)
+    with open(args.gfa_unitigs + ".sig", "wt") as fp:
+        sourmash.save_signatures([in_sig], fp)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/spacegraphcats/cdbg/sort_gfa_unitigs.py
+++ b/spacegraphcats/cdbg/sort_gfa_unitigs.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 """
-Sort the bcalm unitigs.fa output (a cDBG) into deterministic order.
+Sort GFA output (a cDBG) into deterministic order.
 Produces output consumed by `bcalm_to_gxt`.
 
 Also saves all of the graph information for later perusal.
@@ -21,7 +21,7 @@ def main(argv):
     parser = argparse.ArgumentParser()
     parser.add_argument("gfa_unitigs", help="input GFA file for cDBG")
     parser.add_argument("sqlite_db_out",
-                        help="output SQLite databsae for unitigs")
+                        help="output SQLite database for unitigs")
     parser.add_argument("mapping_pickle_out",
                         help="output pickle file for graph structure")
     parser.add_argument("--sig")

--- a/spacegraphcats/conf/Snakefile
+++ b/spacegraphcats/conf/Snakefile
@@ -197,6 +197,7 @@ if 0:
 
 # build catlas input from cdbg output by reformatting; optionally,
 # remove pendants
+# @CTB rename away from bcalm.
 rule cdbg_catlas_prepare_input:
     input:
         db = f"{cdbg_dir}/unitigs.predb",

--- a/spacegraphcats/conf/Snakefile
+++ b/spacegraphcats/conf/Snakefile
@@ -165,7 +165,7 @@ rule bcalm_cdbg:
         rm -f {cdbg_dir}/bcalm.{{h5,unitigs.fa.glue*}}
     """
 
-# create list of input files for bcalm
+# create list of input files for bcalm and bifrost
 rule bcalm_cdbg_inpfiles:
     input:
         input_sequences
@@ -177,52 +177,91 @@ rule bcalm_cdbg_inpfiles:
                 fp.write(f'{name}\n')
 
 # sort and remap bcalm output
-rule bcalm_catlas_sort:
-    input:
-        unitigs = f"{cdbg_dir}/bcalm.unitigs.fa",
-    output:
-        db = f"{cdbg_dir}/bcalm.unitigs.predb",
-        mapping = f"{cdbg_dir}/bcalm.unitigs.pickle",
-        sig = f"{cdbg_dir}/bcalm.unitigs.fa.sig",
-    shadow: "shallow"
-    params:
-        ksize = ksize,
-        seed = cdbg_shuffle_seed if cdbg_shuffle_seed is not None else 42
-    shell: """
-        python -Werror -m spacegraphcats.cdbg.sort_bcalm_unitigs \
-            -k {params.ksize} {input.unitigs} {output.db} {output.mapping} \
-            --seed {params.seed}
-     """
+if 0:
+    rule bcalm_catlas_sort:
+        input:
+            unitigs = f"{cdbg_dir}/bcalm.unitigs.fa",
+        output:
+            db = f"{cdbg_dir}/unitigs.predb",
+            mapping = f"{cdbg_dir}/unitigs.pickle",
+            sig = f"{cdbg_dir}/unitigs.fa.sig",
+        shadow: "shallow"
+        params:
+            ksize = ksize,
+            seed = cdbg_shuffle_seed if cdbg_shuffle_seed is not None else 42
+        shell: """
+            python -Werror -m spacegraphcats.cdbg.sort_bcalm_unitigs \
+                -k {params.ksize} {input.unitigs} {output.db} {output.mapping} \
+                --seed {params.seed}
+         """
 
-# build catlas input from bcalm output by reformatting; optionally,
+# build catlas input from cdbg output by reformatting; optionally,
 # remove pendants
-rule bcalm_catlas_prepare_input:
+rule cdbg_catlas_prepare_input:
     input:
-        unitigs = f"{cdbg_dir}/bcalm.unitigs.fa",
-        db = f"{cdbg_dir}/bcalm.unitigs.predb",
-        mapping = f"{cdbg_dir}/bcalm.unitigs.pickle",
+        db = f"{cdbg_dir}/unitigs.predb",
+        mapping = f"{cdbg_dir}/unitigs.pickle",
     output:
         gxt = f"{cdbg_dir}/cdbg.gxt",
         info = f"{cdbg_dir}/contigs.info.csv",
         sig = f"{cdbg_dir}/contigs.sig",
-        db = f"{cdbg_dir}/bcalm.unitigs.db",
+        db = f"{cdbg_dir}/unitigs.db",
     shadow: "shallow"
     params:
-        remove_pendants = "-P" if config.get('keep_graph_pendants', 0) else "",
+        #remove_pendants = "-P" if config.get('keep_graph_pendants', 0) else "",
+        remove_pendants = "",
         contigs_prefix = f"{cdbg_dir}/contigs"
     shell: """
         python -Werror -m spacegraphcats.cdbg.bcalm_to_gxt \
             {params.remove_pendants} \
-            {input.unitigs} {input.db} {input.mapping} \
+            {input.db} {input.mapping} \
             {output.gxt} {params.contigs_prefix}
         mv {input.db} {output.db}
         chmod u-w {output.db}
      """
 
+
+# build cDBG using bifrost
+rule bifrost_cdbg:
+    input:
+        f"{cdbg_dir}/bcalm.inputlist.txt"
+    output:
+        temp(f"{cdbg_dir}/bifrost.unitigs.gfa"),
+    log: f"{cdbg_dir}/bifrost.log.txt",
+    threads: 16
+    shadow: "shallow"
+    params:
+        gfa_prefix = lambda wildcards, output: output[0][:-4]
+    shell: """
+        # ok, run bifrost
+        echo {params.gfa_prefix}
+        Bifrost build -r {input} -o {params.gfa_prefix} -t {threads} \
+           -k {ksize} -v > >(tee -a {log} >& 2)
+    """
+
+
+# sort and remap bifrost output
+rule bifrost_catlas_sort:
+    input:
+        unitigs = f"{cdbg_dir}/bifrost.unitigs.gfa",
+    output:
+        db = f"{cdbg_dir}/unitigs.predb",
+        mapping = f"{cdbg_dir}/unitigs.pickle",
+        sig = f"{cdbg_dir}/unitigs.sig",
+    shadow: "shallow"
+    params:
+        ksize = ksize,
+        seed = cdbg_shuffle_seed if cdbg_shuffle_seed is not None else 42
+    shell: """
+        python -Werror -m spacegraphcats.cdbg.sort_gfa_unitigs \
+            -k {params.ksize} {input.unitigs} {output.db} {output.mapping} \
+            --seed {params.seed} --sig {output.sig}
+     """
+
 # output contigs file
 rule dump_contigs:
     input:
-        db = f"{cdbg_dir}/bcalm.unitigs.db",
+        db = f"{cdbg_dir}/unitigs.db",
     output:
         f"{cdbg_dir}/contigs.fa.gz"
     shell: """
@@ -274,7 +313,7 @@ rule build_catlas:
 # index contigs, count node sizes
 rule make_contigs_kmer_index:
     input:
-        db = f"{cdbg_dir}/bcalm.unitigs.db",
+        db = f"{cdbg_dir}/unitigs.db",
     output:
         f"{cdbg_dir}/contigs.mphf",
         f"{cdbg_dir}/contigs.indices",
@@ -309,7 +348,7 @@ rule search:
         f"{cdbg_dir}/contigs.mphf",
         f"{cdbg_dir}/contigs.indices",
         f"{cdbg_dir}/contigs.info.csv",
-        db = f"{cdbg_dir}/bcalm.unitigs.db",
+        db = f"{cdbg_dir}/unitigs.db",
     output:
         f"{search_dir}/results.csv",
         make_query_base(config['search']),
@@ -342,7 +381,7 @@ def make_extract_reads_base(searchfiles):
 # get contigs for a single query
 rule extract_contigs_single_file:
     input:
-        db = f"{cdbg_dir}/bcalm.unitigs.db",
+        db = f"{cdbg_dir}/unitigs.db",
         cdbg_ids = f"{search_dir}/{{queryname}}.cdbg_ids.txt.gz",
     output:
         f"{search_dir}/{{queryname}}.cdbg_ids.contigs.fa.gz",
@@ -406,7 +445,7 @@ rule extract_reads_for_decomposition:
 # build hashval query index
 rule build_hashval_query_index:
     input:
-        f"{cdbg_dir}/bcalm.unitigs.db",
+        f"{cdbg_dir}/unitigs.db",
     output:
         f"{hashval_query_dir}/index.pickle",
     params:
@@ -422,7 +461,7 @@ checkpoint hashval_query:
         queries = hashval_queries,
         pickle = f"{hashval_query_dir}/index.pickle",
         catlas = f"{catlas_dir}/catlas.csv",
-        contigs_db = f"{cdbg_dir}/bcalm.unitigs.db"
+        contigs_db = f"{cdbg_dir}/unitigs.db"
     output:
         csv=f"{hashval_query_dir}/hashval_results.csv",
         outdir=directory(f"{hashval_query_dir}/contigs"),
@@ -481,7 +520,7 @@ rule extract_by_shadow_ratio_rule:
     input:
         doms = f"{catlas_dir}/first_doms.txt",
         catlas = f"{catlas_dir}/catlas.csv",
-        contigs_db = f"{cdbg_dir}/bcalm.unitigs.db",
+        contigs_db = f"{cdbg_dir}/unitigs.db",
     output:
         catlas_dir + ".shadow.{shadow_ratio_maxsize}.fa"
     shell: """
@@ -500,7 +539,7 @@ rule multifasta_query:
 
 rule build_multifasta_hashval_index:
     input:
-        f"{cdbg_dir}/bcalm.unitigs.db",
+        f"{cdbg_dir}/unitigs.db",
     output:
         f"{catlas_dir}_multifasta/hashval.pickle",
     params:

--- a/tests/test_dory_workflow.py
+++ b/tests/test_dory_workflow.py
@@ -188,10 +188,10 @@ def test_dory_query_workflow(location):
     kmer_idx = MPHF_KmerIndex.from_directory("dory_k21")
 
     # CTB: these are brittle with the hashing function.
-    #assert kmer_idx.table[10218271035842461694] == 118
-    #assert kmer_idx.table[8436068710919520258] == 118
-    #assert kmer_idx.table[13994045974119358468] == 118
-    #assert kmer_idx.table[11971930231572094512] == 187
+    assert kmer_idx.table[11004452562135275780] == 187
+    assert kmer_idx.table[18392389941331767593] == 187
+    assert kmer_idx.table[5870372511640715632] == 187
+    assert kmer_idx.table[15614278719837004159] == 118
 
     # do search!!
     args = "dory_k21 dory_k21_r1 dory_k21_r1_search_oh0 --query dory-head.fa -k 21 --contigs-db dory_k21/bcalm.unitigs.db".split()
@@ -304,10 +304,10 @@ def test_dory_query_workflow_checkpoint(location):
     kmer_idx = MPHF_KmerIndex.from_directory("dory_k21")
 
     # CTB: these are brittle with the hashing function.
-    #assert kmer_idx.table[10218271035842461694] == 118
-    #assert kmer_idx.table[8436068710919520258] == 118
-    #assert kmer_idx.table[13994045974119358468] == 118
-    #assert kmer_idx.table[11971930231572094512] == 187
+    assert kmer_idx.table[11004452562135275780] == 187
+    assert kmer_idx.table[18392389941331767593] == 187
+    assert kmer_idx.table[5870372511640715632] == 187
+    assert kmer_idx.table[15614278719837004159] == 118
 
     # do search!!
     args = "dory_k21 dory_k21_r1 dory_k21_r1_search_oh0 --query dory-head.fa -k 21 --contigs-db dory_k21/bcalm.unitigs.db".split()

--- a/tests/test_dory_workflow.py
+++ b/tests/test_dory_workflow.py
@@ -186,10 +186,12 @@ def test_dory_query_workflow(location):
 
     # check that we get the kmer -> cDBG assignments we expect
     kmer_idx = MPHF_KmerIndex.from_directory("dory_k21")
-    assert kmer_idx.table[10218271035842461694] == 118
-    assert kmer_idx.table[8436068710919520258] == 118
-    assert kmer_idx.table[13994045974119358468] == 118
-    assert kmer_idx.table[11971930231572094512] == 187
+
+    # CTB: these are brittle with the hashing function.
+    #assert kmer_idx.table[10218271035842461694] == 118
+    #assert kmer_idx.table[8436068710919520258] == 118
+    #assert kmer_idx.table[13994045974119358468] == 118
+    #assert kmer_idx.table[11971930231572094512] == 187
 
     # do search!!
     args = "dory_k21 dory_k21_r1 dory_k21_r1_search_oh0 --query dory-head.fa -k 21 --contigs-db dory_k21/bcalm.unitigs.db".split()
@@ -300,10 +302,12 @@ def test_dory_query_workflow_checkpoint(location):
 
     # check that we get the kmer -> cDBG assignments we expect
     kmer_idx = MPHF_KmerIndex.from_directory("dory_k21")
-    assert kmer_idx.table[10218271035842461694] == 118
-    assert kmer_idx.table[8436068710919520258] == 118
-    assert kmer_idx.table[13994045974119358468] == 118
-    assert kmer_idx.table[11971930231572094512] == 187
+
+    # CTB: these are brittle with the hashing function.
+    #assert kmer_idx.table[10218271035842461694] == 118
+    #assert kmer_idx.table[8436068710919520258] == 118
+    #assert kmer_idx.table[13994045974119358468] == 118
+    #assert kmer_idx.table[11971930231572094512] == 187
 
     # do search!!
     args = "dory_k21 dory_k21_r1 dory_k21_r1_search_oh0 --query dory-head.fa -k 21 --contigs-db dory_k21/bcalm.unitigs.db".split()


### PR DESCRIPTION
**Note:** This is a PR into #429.

**Note:** this will almost certainly require rebuilding all output files. So, should probably be explored in conjunction with #429 😁 

---

spacegraphcats 2.0 uses [bcalm](https://github.com/GATB/bcalm) to build cDBGs; from bcalm, we use the unitigs themselves, as well as the edges between the unitigs, and the abundances of the unitigs (based on k-mers).

However, we would like to enable other cDBG construction mechanisms (e.g. [bifrost](https://github.com/pmelsted/bifrost) #297 and [cuttlefish](https://github.com/COMBINE-lab/cuttlefish) #427), and they provide [GFA](https://github.com/GFA-spec/GFA-spec/blob/master/GFA-spec.md) for output.

So, this PR is exploring options - so far, it

* adds scripts to (begin to) parse GFA output
* switches over to using [bifrost](https://github.com/pmelsted/bifrost) instead of bcalm to build the cDBG

Notes:
* I decided not to use [gfapy](https://gfapy.readthedocs.io/en/latest/) because it reads the entire graph into memory.

TODO:
- [ ] figure out how to add abundances back in, and restore pendant removal options
- [ ] make bcalm vs bifrost a configuration option
- [ ] fix tests ;)

---

## benchmark summary

| what | wall time | RAM |
| -------- | -------- | -------- |
| bcalm, twofoo, 2 threads     | 70s | 1.0 GB |
| bifrost, twofoo, 2 threads   | 51s | 120 MB |
| bcalm, hu-s1, 5+ threads | 19m 40s | 14.0 GB |
| bifrost, hu-s1, 2 threads | 40m 40s | 7.6 GB |
| bcalm, podarV, 5+ threads | 20m 37s | 10.8 GB |
| bifrost, podarV, 2 threads | 30m 14s | 4.0 GB |

[(hackmd)](https://hackmd.io/Vr60XzoTRxeU51eW3rus8Q)
