### PR TITLE
[MRG] switch 'master' refs over to 'latest' in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # spacegraphcats
 
-![Test](https://github.com/spacegraphcats/spacegraphcats/workflows/Test/badge.svg) [![codecov](https://codecov.io/gh/spacegraphcats/spacegraphcats/branch/master/graph/badge.svg)](https://codecov.io/gh/spacegraphcats/spacegraphcats) [![DOI](https://zenodo.org/badge/58208221.svg)](https://zenodo.org/badge/latestdoi/58208221) <a href="https://pypi.org/project/spacegraphcats/"><img alt="PyPI" src="https://badge.fury.io/py/spacegraphcats.svg"></a>
+![Test](https://github.com/spacegraphcats/spacegraphcats/workflows/Test/badge.svg) [![codecov](https://codecov.io/gh/spacegraphcats/spacegraphcats/branch/latest/graph/badge.svg)](https://codecov.io/gh/spacegraphcats/spacegraphcats) [![DOI](https://zenodo.org/badge/58208221.svg)](https://zenodo.org/badge/latestdoi/58208221) <a href="https://pypi.org/project/spacegraphcats/"><img alt="PyPI" src="https://badge.fury.io/py/spacegraphcats.svg"></a>
 
 
 Explore large, annoying graphs using hierarchies of dominating sets - because
@@ -13,7 +13,7 @@ This is a collaboration between the
 Initial development of spacegraphcats was generously supported by the Moore Foundation's
 [Data Driven Discovery Initiative](https://www.moore.org/initiative-strategy-detail?initiativeId=data-driven-discovery).
 
-![spacegraphcats graph](https://github.com/spacegraphcats/spacegraphcats/raw/master/pics/logo.png)
+![spacegraphcats graph](https://github.com/spacegraphcats/spacegraphcats/raw/latest/pics/logo.png)
 
 ## Documentation
 
@@ -22,7 +22,7 @@ For use cases and other information, please see the spacegraphcats documentation
 
 ## Installation and execution quickstart
 
-See [installation instructions](https://github.com/spacegraphcats/spacegraphcats/blob/master/doc/installing-spacegraphcats.md) and [the run guide](https://github.com/spacegraphcats/spacegraphcats/blob/master/doc/running-spacegraphcats.md).
+See [installation instructions](https://github.com/spacegraphcats/spacegraphcats/blob/latest/doc/installing-spacegraphcats.md) and [the run guide](https://github.com/spacegraphcats/spacegraphcats/blob/latest/doc/running-spacegraphcats.md).
 
 For help or support with this software, please
 [file an issue on GitHub](https://github.com/spacegraphcats/spacegraphcats/issues). Thank
@@ -59,19 +59,19 @@ See the Genome Biology publication [Exploring neighborhoods in large metagenome 
 ### Interesting algorithms
 
 The `rdomset` code for efficently calculating a dominating set of a graph
-at a given radius R is in [spacegraphcats/catlas/rdomset.py](https://github.com/spacegraphcats/spacegraphcats/blob/master/spacegraphcats/catlas/rdomset.py).
+at a given radius R is in [spacegraphcats/catlas/rdomset.py](https://github.com/spacegraphcats/spacegraphcats/blob/latest/spacegraphcats/catlas/rdomset.py).
 
 The graph denoising code for removing low-abundance pendants from
 BCALM cDBGs is in function `contract_degree_two` in
-[cdbg/bcalm_to_gxt.py](https://github.com/spacegraphcats/spacegraphcats/blob/master/spacegraphcats/cdbg/bcalm_to_gxt.py).
+[cdbg/bcalm_to_gxt.py](https://github.com/spacegraphcats/spacegraphcats/blob/latest/spacegraphcats/cdbg/bcalm_to_gxt.py).
 
 Part of the `indexPieces` code for indexing cDBG nodes by dominating
 nodes is
-[cdbg/index_contigs_by_kmer.py](https://github.com/spacegraphcats/spacegraphcats/blob/master/spacegraphcats/cdbg/index_contigs_by_kmer.py). The
+[cdbg/index_contigs_by_kmer.py](https://github.com/spacegraphcats/spacegraphcats/blob/latest/spacegraphcats/cdbg/index_contigs_by_kmer.py). The
 remainder is implemented in `search`, below.
 
 The `search` code for extracting query neighborhoods is in
-[search/extract_nodes_by_query.py](https://github.com/spacegraphcats/spacegraphcats/blob/master/spacegraphcats/search/extract_nodes_by_query.py);
+[search/extract_nodes_by_query.py](https://github.com/spacegraphcats/spacegraphcats/blob/latest/spacegraphcats/search/extract_nodes_by_query.py);
 see especially the call to `kmer_idx.count_cdbg_matches(...)`.
 
 ### Interesting library functionality
@@ -79,7 +79,7 @@ see especially the call to `kmer_idx.count_cdbg_matches(...)`.
 Code for indexing large FASTQ/FASTA read files by cDBG unitig, and
 extracting the reads corresponding to individual unitigs from BGZF
 files, is available in
-[cdbg/label_cdbg.py](https://github.com/spacegraphcats/spacegraphcats/blob/master/spacegraphcats/cdbg/label_cdbg.py)
+[cdbg/label_cdbg.py](https://github.com/spacegraphcats/spacegraphcats/blob/latest/spacegraphcats/cdbg/label_cdbg.py)
 and
-[search/search_utils.py](https://github.com/spacegraphcats/spacegraphcats/blob/master/spacegraphcats/search/search_utils.py),
+[search/search_utils.py](https://github.com/spacegraphcats/spacegraphcats/blob/latest/spacegraphcats/search/search_utils.py),
 `get_reads_by_cdbg`, respectively.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For use cases and other information, please see the spacegraphcats documentation
 
 ## Installation and execution quickstart
 
-See [installation instructions](https://github.com/spacegraphcats/spacegraphcats/blob/latest/doc/installing-spacegraphcats.md) and [the run guide](https://github.com/spacegraphcats/spacegraphcats/blob/latest/doc/running-spacegraphcats.md).
+See [installation instructions](https://github.com/spacegraphcats/spacegraphcats/blob/latest/doc/00-installing-spacegraphcats.md) and [the run guide](https://github.com/spacegraphcats/spacegraphcats/blob/latest/doc/01-running-spacegraphcats.md).
 
 For help or support with this software, please
 [file an issue on GitHub](https://github.com/spacegraphcats/spacegraphcats/issues). Thank
@@ -67,11 +67,11 @@ BCALM cDBGs is in function `contract_degree_two` in
 
 Part of the `indexPieces` code for indexing cDBG nodes by dominating
 nodes is
-[cdbg/index_contigs_by_kmer.py](https://github.com/spacegraphcats/spacegraphcats/blob/latest/spacegraphcats/cdbg/index_contigs_by_kmer.py). The
+[cdbg/index_cdbg_by_kmer.py](https://github.com/spacegraphcats/spacegraphcats/blob/latest/spacegraphcats/cdbg/index_cdbg_by_kmer.py). The
 remainder is implemented in `search`, below.
 
 The `search` code for extracting query neighborhoods is in
-[search/extract_nodes_by_query.py](https://github.com/spacegraphcats/spacegraphcats/blob/latest/spacegraphcats/search/extract_nodes_by_query.py);
+[search/query_by_sequence.py](https://github.com/spacegraphcats/spacegraphcats/blob/latest/spacegraphcats/search/query_by_sequence.py);
 see especially the call to `kmer_idx.count_cdbg_matches(...)`.
 
 ### Interesting library functionality
@@ -79,7 +79,7 @@ see especially the call to `kmer_idx.count_cdbg_matches(...)`.
 Code for indexing large FASTQ/FASTA read files by cDBG unitig, and
 extracting the reads corresponding to individual unitigs from BGZF
 files, is available in
-[cdbg/label_cdbg.py](https://github.com/spacegraphcats/spacegraphcats/blob/latest/spacegraphcats/cdbg/label_cdbg.py)
+[cdbg/label_cdbg.py](https://github.com/spacegraphcats/spacegraphcats/blob/latest/spacegraphcats/cdbg/index_reads.py)
 and
 [search/search_utils.py](https://github.com/spacegraphcats/spacegraphcats/blob/latest/spacegraphcats/search/search_utils.py),
 `get_reads_by_cdbg`, respectively.

--- a/doc/developing-spacegraphcats.md
+++ b/doc/developing-spacegraphcats.md
@@ -55,7 +55,7 @@ Then, we build a table that connects query k-mers to cDBG unitig IDs.
 Here the offset in the table is the MPHF of the query k-mer, built using bbhash, and the value in the table is the number of the cDBG unitig. 
 This connects with internal spacegraphcats stuff.
 
-Last but not least, we build a sqlite unitig-to-read offset table in [label_cdbg.py](https://github.com/spacegraphcats/spacegraphcats/blob/latest/spacegraphcats/cdbg/label_cdbg.py). 
+Last but not least, we build a sqlite unitig-to-read offset table in [index_cdbg_by_kmer.py](https://github.com/spacegraphcats/spacegraphcats/blob/latest/spacegraphcats/cdbg/index_cdbg_by_kmer.py). 
 This is a multimap table (read, unitig ID) that lets us query for the BGZF offset for all reads that belong to a given unitig ID. 
 Once we have the read offsets for a given unitig ID, using the bgzf code we can reach into a sequence file and retrieve the relevant read(s) directly. 
 

--- a/doc/developing-spacegraphcats.md
+++ b/doc/developing-spacegraphcats.md
@@ -45,17 +45,17 @@ For a brief look at some internal commands, see [this slideshow](https://hackmd.
 Spacegraphcats optionally outputs the reads that contain k-mers in a neighborhood. 
 This requires being able to go from k-mer to cDBG unitig to read. 
 Below we describe how is this implemented.
-The code for that retrieval is in [extract_reads.py](https://github.com/spacegraphcats/spacegraphcats/blob/master/spacegraphcats/search/extract_reads.py).
+The code for that retrieval is in [extract_reads.py](https://github.com/spacegraphcats/spacegraphcats/blob/latest/spacegraphcats/search/extract_reads.py).
 
 First, we put all of the reads in a BGZF file, which is a gzipped file that can be accessed by position. 
 This lets us retrieve reads based solely on an offset into that file. 
-See [make_bgzf.py](https://github.com/spacegraphcats/spacegraphcats/blob/master/spacegraphcats/utils/make_bgzf.py) and [bgzf/](https://github.com/spacegraphcats/spacegraphcats/tree/master/spacegraphcats/utils/bgzf) for our copy of the BGZF indexing code, taken from BioPython.
+See [make_bgzf.py](https://github.com/spacegraphcats/spacegraphcats/blob/latest/spacegraphcats/utils/make_bgzf.py) and [bgzf/](https://github.com/spacegraphcats/spacegraphcats/tree/latest/spacegraphcats/utils/bgzf) for our copy of the BGZF indexing code, taken from BioPython.
 
 Then, we build a table that connects query k-mers to cDBG unitig IDs. 
 Here the offset in the table is the MPHF of the query k-mer, built using bbhash, and the value in the table is the number of the cDBG unitig. 
 This connects with internal spacegraphcats stuff.
 
-Last but not least, we build a sqlite unitig-to-read offset table in [label_cdbg.py](https://github.com/spacegraphcats/spacegraphcats/blob/master/spacegraphcats/cdbg/label_cdbg.py). 
+Last but not least, we build a sqlite unitig-to-read offset table in [label_cdbg.py](https://github.com/spacegraphcats/spacegraphcats/blob/latest/spacegraphcats/cdbg/label_cdbg.py). 
 This is a multimap table (read, unitig ID) that lets us query for the BGZF offset for all reads that belong to a given unitig ID. 
 Once we have the read offsets for a given unitig ID, using the bgzf code we can reach into a sequence file and retrieve the relevant read(s) directly. 
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -8,7 +8,7 @@ This is a collaboration between the
 Initial development of spacegraphcats was generously supported by the Moore Foundation's
 [Data Driven Discovery Initiative](https://www.moore.org/initiative-strategy-detail?initiativeId=data-driven-discovery).
 
-![spacegraphcats graph](https://github.com/spacegraphcats/spacegraphcats/raw/master/pics/logo.png)
+![spacegraphcats graph](https://github.com/spacegraphcats/spacegraphcats/raw/latest/pics/logo.png)
 
 ## Citation information
 


### PR DESCRIPTION
This is a minor update to the docs to swizzle the remaining references to `master` branch to refer to `latest`, instead.

TODO:
- [x] manually verify that all the links work