### PR TITLE
[MRG] remove unnecessary bcalm_unitigs cli arg

### DIFF
--- a/spacegraphcats/cdbg/bcalm_to_gxt.py
+++ b/spacegraphcats/cdbg/bcalm_to_gxt.py
@@ -202,7 +202,6 @@ class SqliteAsDict:
 
 def main(argv):
     parser = argparse.ArgumentParser()
-    parser.add_argument("bcalm_unitigs")
     parser.add_argument("sqlite_db")
     parser.add_argument("mapping_pickle")
     parser.add_argument("gxt_out")

--- a/spacegraphcats/conf/Snakefile
+++ b/spacegraphcats/conf/Snakefile
@@ -198,7 +198,6 @@ rule bcalm_catlas_sort:
 # remove pendants
 rule bcalm_catlas_prepare_input:
     input:
-        unitigs = f"{cdbg_dir}/bcalm.unitigs.fa",
         db = f"{cdbg_dir}/bcalm.unitigs.predb",
         mapping = f"{cdbg_dir}/bcalm.unitigs.pickle",
     output:
@@ -213,7 +212,7 @@ rule bcalm_catlas_prepare_input:
     shell: """
         python -Werror -m spacegraphcats.cdbg.bcalm_to_gxt \
             {params.remove_pendants} \
-            {input.unitigs} {input.db} {input.mapping} \
+            {input.db} {input.mapping} \
             {output.gxt} {params.contigs_prefix}
         mv {input.db} {output.db}
         chmod u-w {output.db}

--- a/tests/test_dory_workflow.py
+++ b/tests/test_dory_workflow.py
@@ -150,7 +150,6 @@ def test_dory_query_workflow(location):
     # convert the bcalm file to gxt
     args = [
         "-P",
-        relative_file("data/bcalm.dory.k21.unitigs.fa"),
         "dory_k21/bcalm.unitigs.db",
         "dory_k21/bcalm.unitigs.pickle",
         "dory_k21/cdbg.gxt",
@@ -264,7 +263,6 @@ def test_dory_query_workflow_checkpoint(location):
     # convert the bcalm file to gxt
     args = [
         "-P",
-        relative_file("data/bcalm.dory.k21.unitigs.fa"),
         "dory_k21/bcalm.unitigs.db",
         "dory_k21/bcalm.unitigs.pickle",
         "dory_k21/cdbg.gxt",
@@ -373,7 +371,6 @@ def test_dory_query_workflow_remove_pendants(location):
 
     # convert the bcalm file to gxt
     args = [
-        relative_file("data/bcalm.dory.k21.unitigs.fa"),
         "dory_k21/bcalm.unitigs.db",
         "dory_k21/bcalm.unitigs.pickle",
         "dory_k21/cdbg.gxt",


### PR DESCRIPTION
While working on #430 I realized that `spacegraphcats/cdbg/bcalm_to_gxt.py` still took an argument `bcalm_unitigs` that it did not, in fact, need or use. This PR removes it from the argument parsing as well as the Snakefile.
