### PR TITLE
[MRG] add translated catlas annotation functionality w/multifasta approach

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ twofoo-test: twofoo.fq.gz # twofoo/bcalm.twofoo.k31.unitigs.fa
 	python -m spacegraphcats run twofoo extract_reads_for_hashvals
 	python -m spacegraphcats.search.characterize_catlas_regions twofoo_k31 twofoo_k31_r1 twofoo_k31_r1.vec --contigs-db twofoo_k31/bcalm.unitigs.db
 	python -m spacegraphcats run twofoo multifasta_query
+	python -m spacegraphcats run twofoo build_cdbg_list_by_record_x
 
 twofoo-clean:
 	rm -fr twofoo twofoo_k31_r1 twofoo_k31_r1_hashval_k51/ \

--- a/spacegraphcats/conf/Snakefile
+++ b/spacegraphcats/conf/Snakefile
@@ -99,12 +99,14 @@ multifasta_query_sig = fix_relative_input_paths([multifasta_query_sig])[0]
 # multifasta protein queries
 
 multifasta_query_x_seqs = config.get('multifasta_reference_x',
-                                    ['** does not exist **'])
+                                     ['** does not exist **'])
 if not isinstance(multifasta_query_x_seqs, list):
     print('ERROR: multifasta_reference_x must be a YAML list.')
     sys.exit(-1)
 
 multifasta_query_x_seqs = fix_relative_input_paths(multifasta_query_x_seqs)
+multifasta_x_ksize = config.get('multifasta_x_protein_ksize', 10)
+multifasta_x_query_is_dna = config.get('multifasta_x_query_is_dna', False)
 
 ### build some variables for internal use
 
@@ -599,11 +601,12 @@ rule build_multifasta_x_index:
     output:
         f"{catlas_dir}_multifasta/multifasta_x.pickle",
     params:
-        ksize = ksize,
+        ksize = multifasta_x_ksize,
+        query_is_dna = "--query-is-dna" if multifasta_x_query_is_dna else ""
     shell: """
         python -Werror -m spacegraphcats.search.index_cdbg_by_multifasta_x \
              {cdbg_dir} {catlas_dir} {output} --query {input.queries} \
-             -k {params.ksize}
+             -k {params.ksize} {params.query_is_dna}
     """
 
 # @CTB

--- a/spacegraphcats/conf/Snakefile
+++ b/spacegraphcats/conf/Snakefile
@@ -83,6 +83,8 @@ if config.get('hashval_queries', ''):
     filename = config.get('hashval_queries', '')
     hashval_queries = fix_relative_input_paths([filename])[0]
 
+# multifasta queries
+
 multifasta_query_seqs = config.get('multifasta_reference',
                                    ['** does not exist **'])
 if not isinstance(multifasta_query_seqs, list):
@@ -93,6 +95,16 @@ multifasta_query_seqs = fix_relative_input_paths(multifasta_query_seqs)
 multifasta_query_sig = config.get('multifasta_query_sig',
                                   '** does not exist **')
 multifasta_query_sig = fix_relative_input_paths([multifasta_query_sig])[0]
+
+# multifasta protein queries
+
+multifasta_query_x_seqs = config.get('multifasta_reference_x',
+                                    ['** does not exist **'])
+if not isinstance(multifasta_query_x_seqs, list):
+    print('ERROR: multifasta_reference_x must be a YAML list.')
+    sys.exit(-1)
+
+multifasta_query_x_seqs = fix_relative_input_paths(multifasta_query_x_seqs)
 
 ### build some variables for internal use
 
@@ -572,3 +584,41 @@ rule extract_reads_single_file_multifasta:
         python -Werror -m spacegraphcats.search.extract_reads {input.reads} \
             {input.labels} {input.cdbg_ids} -o {output}
     """
+
+
+# build multifasta_x annotation/index for translated queries
+
+rule build_multifasta_x_index:
+    input:
+        queries = multifasta_query_x_seqs,
+        doms = f"{catlas_dir}/first_doms.txt",
+        catlas = f"{catlas_dir}/catlas.csv",
+        mphf = f"{cdbg_dir}/contigs.mphf",
+        indices = f"{cdbg_dir}/contigs.indices",
+        sizes = f"{cdbg_dir}/contigs.sizes",
+    output:
+        f"{catlas_dir}_multifasta/multifasta_x.pickle",
+    params:
+        ksize = ksize,
+    shell: """
+        python -Werror -m spacegraphcats.search.index_cdbg_by_multifasta_x \
+             {cdbg_dir} {catlas_dir} {output} --query {input.queries} \
+             -k {params.ksize}
+    """
+
+# @CTB
+# this rule also creates a bunch of files named record{n}-nbhd.cdbg_ids.txt.gz
+# see rule extract_reads_single_hashval_file for how to get the reads.
+rule build_cdbg_list_by_record_x:
+    input:
+        multi_idx = f"{catlas_dir}_multifasta/multifasta.pickle",
+        info_csv = f"{cdbg_dir}/contigs.info.csv",
+    output:
+        cdbg_record = f"{catlas_dir}_multifasta/multifasta_x.cdbg_by_record.csv",
+        cdbg_annot = f"{catlas_dir}_multifasta/multifasta_x.cdbg_annot.csv",
+    shell: """
+        python -Werror -m spacegraphcats.search.extract_cdbg_by_multifasta \
+            --multi-idx {input.multi_idx} --output-cdbg-record {output.cdbg_record} \
+            --output-cdbg-annot {output.cdbg_annot} --info-csv {input.info_csv}
+    """
+

--- a/spacegraphcats/conf/Snakefile
+++ b/spacegraphcats/conf/Snakefile
@@ -599,7 +599,7 @@ rule build_multifasta_x_index:
         indices = f"{cdbg_dir}/contigs.indices",
         sizes = f"{cdbg_dir}/contigs.sizes",
     output:
-        f"{catlas_dir}_multifasta/multifasta_x.pickle",
+        f"{catlas_dir}_multifasta_x/multifasta_x.pickle",
     params:
         ksize = multifasta_x_ksize,
         query_is_dna = "--query-is-dna" if multifasta_x_query_is_dna else ""
@@ -609,19 +609,17 @@ rule build_multifasta_x_index:
              -k {params.ksize} {params.query_is_dna}
     """
 
-# @CTB
 # this rule also creates a bunch of files named record{n}-nbhd.cdbg_ids.txt.gz
 # see rule extract_reads_single_hashval_file for how to get the reads.
 rule build_cdbg_list_by_record_x:
     input:
-        multi_idx = f"{catlas_dir}_multifasta/multifasta.pickle",
+        multi_idx = f"{catlas_dir}_multifasta_x/multifasta_x.pickle",
         info_csv = f"{cdbg_dir}/contigs.info.csv",
     output:
-        cdbg_record = f"{catlas_dir}_multifasta/multifasta_x.cdbg_by_record.csv",
-        cdbg_annot = f"{catlas_dir}_multifasta/multifasta_x.cdbg_annot.csv",
+        cdbg_record = f"{catlas_dir}_multifasta_x/multifasta_x.cdbg_by_record.csv",
+        cdbg_annot = f"{catlas_dir}_multifasta_x/multifasta_x.cdbg_annot.csv",
     shell: """
         python -Werror -m spacegraphcats.search.extract_cdbg_by_multifasta \
             --multi-idx {input.multi_idx} --output-cdbg-record {output.cdbg_record} \
             --output-cdbg-annot {output.cdbg_annot} --info-csv {input.info_csv}
     """
-

--- a/spacegraphcats/conf/Snakefile
+++ b/spacegraphcats/conf/Snakefile
@@ -98,7 +98,7 @@ multifasta_query_sig = fix_relative_input_paths([multifasta_query_sig])[0]
 
 # multifasta protein queries
 
-multifasta_query_x_seqs = config.get('multifasta_reference_x',
+multifasta_query_x_seqs = config.get('multifasta_x_reference',
                                      ['** does not exist **'])
 if not isinstance(multifasta_query_x_seqs, list):
     print('ERROR: multifasta_reference_x must be a YAML list.')

--- a/spacegraphcats/conf/dory-test.yaml
+++ b/spacegraphcats/conf/dory-test.yaml
@@ -21,4 +21,4 @@ multifasta_query_sig: data/dory-subset.fq.sig
 multifasta_reference_x:
 - data/dory-prot-query.faa
 multifasta_x_protein_ksize: 10
-multifasta_x_query_is_dna: true
+multifasta_x_query_is_dna: false

--- a/spacegraphcats/conf/dory-test.yaml
+++ b/spacegraphcats/conf/dory-test.yaml
@@ -17,3 +17,9 @@ multifasta_reference:
 - data/dory-head.fa
 multifasta_scaled: 100
 multifasta_query_sig: data/dory-subset.fq.sig
+
+multifasta_reference_x:
+- data/dory-prot-query.faa
+# @CTB add ksize, query_is_protein
+
+

--- a/spacegraphcats/conf/dory-test.yaml
+++ b/spacegraphcats/conf/dory-test.yaml
@@ -20,4 +20,5 @@ multifasta_query_sig: data/dory-subset.fq.sig
 
 multifasta_reference_x:
 - data/dory-prot-query.faa
-# @CTB add ksize, query_is_protein
+multifasta_x_protein_ksize: 10
+multifasta_x_query_is_dna: true

--- a/spacegraphcats/conf/dory-test.yaml
+++ b/spacegraphcats/conf/dory-test.yaml
@@ -21,5 +21,3 @@ multifasta_query_sig: data/dory-subset.fq.sig
 multifasta_reference_x:
 - data/dory-prot-query.faa
 # @CTB add ksize, query_is_protein
-
-

--- a/spacegraphcats/conf/dory-test.yaml
+++ b/spacegraphcats/conf/dory-test.yaml
@@ -18,7 +18,7 @@ multifasta_reference:
 multifasta_scaled: 100
 multifasta_query_sig: data/dory-subset.fq.sig
 
-multifasta_reference_x:
+multifasta_x_reference:
 - data/dory-prot-query.faa
 multifasta_x_protein_ksize: 10
 multifasta_x_query_is_dna: false

--- a/spacegraphcats/conf/twofoo.yaml
+++ b/spacegraphcats/conf/twofoo.yaml
@@ -18,6 +18,6 @@ multifasta_scaled: 1000
 multifasta_query_sig: data/63-os223.sig
 
 multifasta_x_reference:
-- XXX
+- data/shew-genes.faa.gz
 multifasta_x_protein_ksize: 10
 multifasta_x_query_is_dna: false

--- a/spacegraphcats/conf/twofoo.yaml
+++ b/spacegraphcats/conf/twofoo.yaml
@@ -16,3 +16,8 @@ multifasta_reference:
 - data/twofoo-genes.fa.gz
 multifasta_scaled: 1000
 multifasta_query_sig: data/63-os223.sig
+
+multifasta_x_reference:
+- XXX
+multifasta_x_protein_ksize: 10
+multifasta_x_query_is_dna: false

--- a/spacegraphcats/search/extract_cdbg_by_multifasta.py
+++ b/spacegraphcats/search/extract_cdbg_by_multifasta.py
@@ -1,4 +1,7 @@
 #! /usr/bin/env python
+"""
+XXX
+"""
 import argparse
 import csv
 import gzip

--- a/spacegraphcats/search/extract_cdbg_by_multifasta.py
+++ b/spacegraphcats/search/extract_cdbg_by_multifasta.py
@@ -1,6 +1,13 @@
 #! /usr/bin/env python
 """
-XXX
+Extract useful information from a multifasta annotation of the cDBG nodes.
+
+This script takes in a multifasta_index produced by index_cdbg_by_multifasta*
+and outputs:
+* a CSV file with one multifasta query per line, containing summary information
+  about the cDBG nodes to which that query matches.
+* individual files for each annotation, listing the cDBG IDs and the name
+  of a (potential) output file for where reads will be extracted.
 """
 import argparse
 import csv
@@ -15,22 +22,20 @@ def main(argv):
     """
 
     p = argparse.ArgumentParser(description=main.__doc__)
-    p.add_argument("--multi-idx")
-    p.add_argument("--info-csv")
-    p.add_argument("--output-cdbg-record")
-    p.add_argument("--output-cdbg-annot")
+    p.add_argument("--multi-idx", required=True)
+    p.add_argument("--info-csv", required=True)
+    p.add_argument("--output-cdbg-record", required=True)
+    p.add_argument("--output-cdbg-annot", required=True)
     args = p.parse_args(argv)
 
-    assert args.multi_idx
-    assert args.output_cdbg_record
-    assert args.output_cdbg_annot
-
+    # load records <-> cDBG dictionaries
     with open(args.multi_idx, "rb") as fp:
         catlas_base, records_to_cdbg, cdbg_to_records = pickle.load(fp)
         print(
             f"loaded {len(cdbg_to_records)} cdbg to sequence record mappings for {catlas_base}"
         )
 
+    # read in the information about the underlying cDBG nodes
     cdbg_info = {}
     with open(args.info_csv, "rt") as fp:
         r = csv.DictReader(fp)
@@ -39,6 +44,7 @@ def main(argv):
             cdbg_info[cdbg_id] = row
         print(f"loaded {len(cdbg_info)} info records for {catlas_base}")
 
+    # create the per-annotation information file.
     with open(args.output_cdbg_record, "wt") as fp:
         w = csv.writer(fp)
         w.writerow(
@@ -53,6 +59,7 @@ def main(argv):
             ]
         )
 
+        # iterate over all annotations {queryfile, query_record} -> cDBG IDs
         filenum = 0
         for (filename, record_name), cdbg_ids in records_to_cdbg.items():
             if not cdbg_ids:

--- a/spacegraphcats/search/index_cdbg_by_multifasta.py
+++ b/spacegraphcats/search/index_cdbg_by_multifasta.py
@@ -1,4 +1,17 @@
 #! /usr/bin/env python
+"""
+Annotate/index the cDBG with FASTA records from one or more DNA query files.
+
+This can be used, for example, to connect cDBG nodes to gene names.
+
+In brief, this script
+- reads query sequences from FASTA files
+- for each query sequence, finds matching cDBG nodes using the k-mer index
+- produces mappings from query to cDBG nodes, and vice versa.
+- saves to pickle file.
+
+See index_cdbg_by_multifasta_x for a protein-space version of this script.
+"""
 import argparse
 import os
 import sys

--- a/spacegraphcats/search/index_cdbg_by_multifasta.py
+++ b/spacegraphcats/search/index_cdbg_by_multifasta.py
@@ -121,10 +121,10 @@ def main(argv):
     with open(outfile, "wb") as fp:
         print(f"saving pickled index to '{outfile}'")
         pickle.dump((args.catlas_prefix, records_to_cdbg, cdbg_to_records), fp)
-        print(f"saved {n_records_found} query names with cDBG node mappings")
+        print(f"saved {n_records_found} query names with cDBG node mappings (of {len(records_to_cdbg)} queries total)")
         n_cdbg_match = len(cdbg_to_records)
         n_cdbg_total = len(catlas.cdbg_to_layer1)
-        print(f"saved {n_cdbg_match} (of {n_cdbg_total} total; {n_cdbg_match / n_cdbg_total * 100:.1f}%) cDBG IDs with at least one query match")
+        print(f"saved {n_cdbg_match} cDBG IDs (of {n_cdbg_total} total; {n_cdbg_match / n_cdbg_total * 100:.1f}%) with at least one query match")
 
     return 0
 

--- a/spacegraphcats/search/index_cdbg_by_multifasta.py
+++ b/spacegraphcats/search/index_cdbg_by_multifasta.py
@@ -94,6 +94,9 @@ def main(argv):
             for cdbg_node in shadow:
                 cdbg_to_records[cdbg_node].add((filename, record.name))
 
+    if not records_to_cdbg:
+        print("WARNING: nothing in query matched to cDBG. Saving empty dictionaries.", file=sys.stderr)
+
     with open(outfile, "wb") as fp:
         print(f"saving pickled index to '{outfile}'")
         pickle.dump((args.catlas_prefix, records_to_cdbg, cdbg_to_records), fp)

--- a/spacegraphcats/search/index_cdbg_by_multifasta_x.py
+++ b/spacegraphcats/search/index_cdbg_by_multifasta_x.py
@@ -1,0 +1,137 @@
+#! /usr/bin/env python
+import argparse
+import os
+import sys
+import time
+import pickle
+from collections import defaultdict
+import sqlite3
+
+import screed
+import sourmash
+
+from ..utils.logging import notify, error
+from . import MPHF_KmerIndex, hash_sequence
+from .catlas import CAtlas
+from . import search_utils
+
+
+def main(argv):
+    """\
+    Query a catlas with a sequence (read, contig, or genome), and retrieve
+    cDBG node IDs and MinHash signatures for the matching unitigs in the graph.
+    """
+
+    p = argparse.ArgumentParser(description=main.__doc__)
+    p.add_argument("cdbg_prefix", help="cdbg prefix")
+    p.add_argument("catlas_prefix", help="catlas prefix")
+    p.add_argument("output")
+    p.add_argument("--query", help="query sequences", nargs="+")
+    # @CTB add to config file for sgc
+    p.add_argument(
+        "-k", "--ksize", default=31, type=int, help="k-mer size (default: 31)"
+    )
+    p.add_argument('--query-is-dna', help='translate query to protein as well',
+                   action='store_true')
+    p.add_argument("-v", "--verbose", action="store_true")
+
+    args = p.parse_args(argv)
+    outfile = args.output
+
+    if not args.query:
+        print("must specify at least one query file using --query.")
+        sys.exit(-1)
+
+    # make sure all of the query sequences exist.
+    for filename in args.query:
+        if not os.path.exists(filename):
+            error("query seq file {} does not exist.", filename)
+            sys.exit(-1)
+
+    # load catlas DAG
+    catlas = CAtlas(args.cdbg_prefix, args.catlas_prefix)
+    notify("loaded {} nodes from catlas {}", len(catlas), args.catlas_prefix)
+    notify("loaded {} layer 1 catlas nodes", len(catlas.layer1_to_cdbg))
+
+    unitigs_db = os.path.join(args.cdbg_prefix, 'bcalm.unitigs.db')
+
+    # get a single ksize for query
+    prot_ksize = int(args.ksize)
+    prot_mh = sourmash.MinHash(n=0, scaled=100, ksize=prot_ksize,
+                               is_protein=True)
+
+    record_kmers = defaultdict(set)
+    all_kmers = set()
+    
+    if args.query_is_dna:
+        add_as_protein = False
+    else:
+        add_as_protein = True
+
+    for filename in args.query:
+        print(f"Reading query from '{filename}'")
+
+        screed_fp = screed.open(filename)
+        for record in screed_fp:
+            these_hashes = prot_mh.seq_to_hashes(record.sequence,
+                                                 is_protein=add_as_protein)
+            these_hashes = set(these_hashes)
+            record_kmers[record.name] = these_hashes
+            all_kmers.update(these_hashes)
+
+    # iterate over unitigs next
+    ## now unitigs... for all of the unitigs (which are DNA),
+    ## first: translate the unitig into protein (up to six sequences),
+    ## second: decompose into k-mers, save k-mers
+    ## third: look for overlaps with query_kmers
+
+    matching_cdbg = defaultdict(set)
+
+    db = sqlite3.connect(unitigs_db)
+    for n, record in enumerate(search_utils.contigs_iter_sqlite(db)):
+
+        # translate into protein sequences
+        seq = record.sequence
+
+        unitig_hashes = prot_mh.seq_to_hashes(record.sequence)
+        unitig_hashes = set(unitig_hashes)
+
+        # do we have an overlap with any query??
+        if unitig_hashes & all_kmers:
+            # yes, match!
+            cdbg_node = int(record.name)
+
+            # iterate over all queries... slow.
+            for query_name, query_hashes in record_kmers.items():
+                # match to this record?
+                if unitig_hashes & query_hashes:
+                    matching_cdbg[query_name].add(cdbg_node)
+
+        screed_fp.close()
+
+    # ok, last iteration? expand neighborhoods.
+    records_to_cdbg = {}
+    cdbg_to_records = defaultdict(set)
+    for query_name, cdbg_nodes in matching_cdbg.items():
+        dominators = set()
+        for cdbg_node in cdbg_nodes:
+            dominators.add(catlas.cdbg_to_layer1[cdbg_node])
+
+        print(f"got {len(dominators)} dominators for {record.name[:15]}")
+
+        shadow = catlas.shadow(dominators)
+        print(f"got {len(shadow)} cdbg_nodes under {len(dominators)} dominators")
+
+        records_to_cdbg[('XXX', record.name)] = shadow
+        for cdbg_node in shadow:
+            cdbg_to_records[cdbg_node].add((filename, record.name))
+
+    with open(outfile, "wb") as fp:
+        print(f"saving pickled index to '{outfile}'")
+        pickle.dump((args.catlas_prefix, records_to_cdbg, cdbg_to_records), fp)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/spacegraphcats/search/index_cdbg_by_multifasta_x.py
+++ b/spacegraphcats/search/index_cdbg_by_multifasta_x.py
@@ -1,4 +1,9 @@
 #! /usr/bin/env python
+"""
+XXX
+
+Translated version of index_cdbg_by_multifasta.py.
+"""
 import argparse
 import os
 import sys
@@ -30,7 +35,8 @@ def main(argv):
 
     # @CTB add this to config file for sgc
     p.add_argument(
-        "-k", "--ksize", default=31, type=int, help="k-mer size (default: 31)"
+        "-k", "--ksize", default=10, type=int,
+        help="protein k-mer size (default: 10)"
     )
     # @CTB add this to config file too :)
     p.add_argument('--query-is-dna', help='translate query to protein as well',

--- a/spacegraphcats/search/index_cdbg_by_multifasta_x.py
+++ b/spacegraphcats/search/index_cdbg_by_multifasta_x.py
@@ -10,10 +10,14 @@ In brief, this script
 - records hashes from query sequences in protein space
 - iterates over the cDBG unitigs and finds cDBG nodes that match to each
   query. (This is potentially a quadratic step.)
+- expands cDBG unitigs into neighborhood using level 1 dominators
 - produces mappings from query to cDBG nodes, and vice versa.
 - saves to pickle file.
 
 See index_cdbg_by_multifasta for a pure DNA-space version of this script.
+
+NOTE: unlike index_cdbg_by_multifasta, query records with no match are NOT
+saved.
 """
 import argparse
 import os
@@ -165,10 +169,10 @@ def main(argv):
     with open(outfile, "wb") as fp:
         print(f"saving pickled index to '{outfile}'")
         pickle.dump((args.catlas_prefix, records_to_cdbg, cdbg_to_records), fp)
-
-    # @CTB remove.
-    import pprint
-    pprint.pprint(records_to_cdbg)
+        print(f"saved {len(records_to_cdbg)} query names with cDBG node mappings")
+        n_cdbg_match = len(cdbg_to_records)
+        n_cdbg_total = len(catlas.cdbg_to_layer1)
+        print(f"saved {n_cdbg_match} (of {n_cdbg_total} total; {n_cdbg_match / n_cdbg_total * 100:.1f}%) cDBG IDs with at least one query match")
 
     return 0
 

--- a/spacegraphcats/search/index_cdbg_by_multifasta_x.py
+++ b/spacegraphcats/search/index_cdbg_by_multifasta_x.py
@@ -96,6 +96,7 @@ def main(argv):
     all_kmers = set()
     
     # read all the queries into memory.
+    n_total_queries = 0
     for filename in args.query:
         print(f"Reading query from '{filename}'")
 
@@ -114,6 +115,7 @@ def main(argv):
                 sys.exit(-1)
 
             query_name_to_filename[record.name] = filename
+            n_total_queries += 1
 
         screed_fp.close()
 
@@ -125,6 +127,7 @@ def main(argv):
 
     matching_cdbg = defaultdict(set)
 
+    print(f"Iterating through unitigs in '{unitigs_db}'")
     db = sqlite3.connect(unitigs_db)
     for n, record in enumerate(search_utils.contigs_iter_sqlite(db)):
         # translate into protein sequences
@@ -169,10 +172,10 @@ def main(argv):
     with open(outfile, "wb") as fp:
         print(f"saving pickled index to '{outfile}'")
         pickle.dump((args.catlas_prefix, records_to_cdbg, cdbg_to_records), fp)
-        print(f"saved {len(records_to_cdbg)} query names with cDBG node mappings")
+        print(f"saved {len(records_to_cdbg)} query names with cDBG node mappings (of {n_total_queries} queries total)")
         n_cdbg_match = len(cdbg_to_records)
         n_cdbg_total = len(catlas.cdbg_to_layer1)
-        print(f"saved {n_cdbg_match} (of {n_cdbg_total} total; {n_cdbg_match / n_cdbg_total * 100:.1f}%) cDBG IDs with at least one query match")
+        print(f"saved {n_cdbg_match} cDBG IDs (of {n_cdbg_total} total; {n_cdbg_match / n_cdbg_total * 100:.1f}%) with at least one query match")
 
     return 0
 

--- a/tests/test_dory_workflow.py
+++ b/tests/test_dory_workflow.py
@@ -1,3 +1,6 @@
+"""
+Test many (most?) spacegraphcats scripts against the 'dory' small example data.
+"""
 import os.path
 import shutil
 import glob
@@ -28,6 +31,7 @@ from spacegraphcats.search import extract_reads
 from spacegraphcats.cdbg import index_cdbg_by_minhash
 from spacegraphcats.search import query_by_hashval
 from spacegraphcats.search import index_cdbg_by_multifasta
+from spacegraphcats.search import index_cdbg_by_multifasta_x
 from spacegraphcats.search import query_multifasta_by_sig
 from spacegraphcats.search import extract_cdbg_by_multifasta
 from spacegraphcats.search import search_utils
@@ -743,6 +747,19 @@ def test_dory_multifasta_query(location):
     assert os.path.exists("dory_k21_r1_multifasta/multifasta.cdbg_by_record.csv")
     assert os.path.exists("dory_k21_r1_multifasta/multifasta.cdbg_annot.csv")
     assert os.path.exists("dory_k21_r1_multifasta/query-results.csv")
+
+
+@pytest_utils.in_tempdir
+def test_dory_multifasta_annot_x(location):
+    copy_dory_head()
+    copy_dory_catlas()
+
+    queryfile = relative_file('data/dory-prot-query.faa')
+
+    # index by multifasta
+    os.mkdir("dory_k21_r1_multifasta")
+    args = f"dory_k21 dory_k21_r1 dory_k21_r1_multifasta/multifasta_x.pickle --query {queryfile} -k 10"
+    assert index_cdbg_by_multifasta_x.main(args.split()) == 0
 
 
 @pytest_utils.in_tempdir


### PR DESCRIPTION
Note: this is a PR into #379, although it doesn't really need to be.

Fixes #437.

This PR extends the multifasta indexing/annotation capabilities added in https://github.com/spacegraphcats/spacegraphcats/pull/282 with protein queries. Briefly, it:
* adds a new script `spacegraphcats/search/index_cdbg_by_multifasta_x.py` that does protein-space search of the cDBG + expansion to neighborhoods;
* adds three new config parameters, `multifasta_x_reference`, `multifasta_x_protein_ksize`, and `multifasta_x_query_is_dna`.
* adds two new concrete targets in the Snakefile, `build_multifasta_x_index` and `build_cdbg_list_by_record_x`;
* the target `build_cdbg_list_by_record_x`  produces a file `{catlas_dir}_multifasta_x/multifasta_x.cdbg_annot.csv` that contains the nice mappings between neighborhoods and protein annotations;
* adds tests and docstrings;

As with protein query of the catlas #379, this PR cannot use the pre-built k-mer index to search the cDBGs. So, it does an iterative search of all the unitigs, which might take a while for large catlases. See some of the benchmark times, below.

TODO:
- [x] fix/retain filenames for each record
- [x] add config options into Snakefile, etc.
- [x] figure out how to produce `multifasta.cdbg_annot.csv`
- [x] testing, robustness, etc.
- [x] evaluate speed, functionality on a bigger catlas than dory...
- [x] add docstrings to top of multifasta scripts

## Example

To annotate the twofoo cDBG with a ~dozen genes, run:

```
python -m spacegraphcats run twofoo build_cdbg_list_by_record_x
```
and you'll get output like so:
```
...
saved 11 query names with cDBG node mappings (of 11 queries total)
saved 355 cDBG IDs (of 206855 total; 0.2%) with at least one query match
```
(This only takes 35 seconds or so, which is pretty good!)

## A larger query: time

I downloaded a full _Shewanella baltica_ proteome, GCF_001620325.1_ASM162032v1_protein.faa.gz, which has almost 4300 proteins in it, and ran this code.

Results:
```
...
saved 3769 query names with cDBG node mappings (of 4255 queries total)
saved 155286 cDBG IDs (of 206855 total; 75.1%) with at least one query match
```
and time:
```
real    0m43.729s
user    0m37.468s
sys     0m2.704s
```
so, that's pretty fast!