### PR TITLE
[MRG] add `mamba` as a conda dependency, b/c snakemake wants it.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
     - numpy
     - pytest=5.3.2
     - sortedcontainers=2.1.0
-    - click=7.1.2
+    - click>=8.1.2,<9
     - pyflakes
     - bbhash>=0.5.4
     - sourmash>=4.2.2,<5

--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,4 @@ dependencies:
     - pyflakes
     - bbhash>=0.5.4
     - sourmash>=4.2.2,<5
+    - mamba>=0.22.1

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
     - defaults
 dependencies:
     - bcalm=2.2.3
-    - snakemake-minimal=6.4.0
+    - snakemake-minimal=7.3.8
     - screed>=1.0.5,<2
     - khmer=3.0.0a3
     - numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pytest >= 5.1.2
 pytest-dependency
 numpy
 pandas
-snakemake == 6.4.0
+snakemake == 7.3.8
 click == 7.1.2
 sortedcontainers
 bbhash >= 0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pytest-dependency
 numpy
 pandas
 snakemake == 7.3.8
-click == 7.1.2
+click >= 8.1.2,<9
 sortedcontainers
 bbhash >= 0.5
 https://github.com/dib-lab/khmer/archive/master.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ snakemake == 7.3.8
 click >= 8.1.2,<9
 sortedcontainers
 bbhash >= 0.5
-https://github.com/dib-lab/khmer/archive/master.zip
+khmer == 3.0.0a3
 sourmash>=4.2.2,<5
 flake8
 black

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ snakemake == 7.3.8
 click >= 8.1.2,<9
 sortedcontainers
 bbhash >= 0.5
-khmer == 3.0.0a3
+khmer
 sourmash>=4.2.2,<5
 flake8
 black

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "screed >= 1.0.5,<2",
         "pytest",
         "numpy",
-        "snakemake==6.4.0",
+        "snakemake==7.3.8",
         "sortedcontainers",
         "sourmash>=4.2.2,<5",
         "khmer==3.0.0a3",

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "snakemake==7.3.8",
         "sortedcontainers",
         "sourmash>=4.2.2,<5",
-        "khmer==3.0.0a3",
+        "khmer",
         "bbhash >= 0.5.4",
         "click >= 8.1.2,<9"
     ],

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         "sourmash>=4.2.2,<5",
         "khmer==3.0.0a3",
         "bbhash >= 0.5.4",
+        "click >= 8.1.2,<9"
     ],
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Fixes https://github.com/spacegraphcats/spacegraphcats/issues/458, by adding `mamba` to environment.yml.

Also updates python deps - snakemake to `=7.3.8`, and click to `>=8.1.2,<9`.
