### PR TITLE
[MRG] Remove kmer size argument from `rule build_multifasta_index` in spacegraphcats/conf/Snakefile

### DIFF
--- a/spacegraphcats/conf/Snakefile
+++ b/spacegraphcats/conf/Snakefile
@@ -534,11 +534,9 @@ rule build_multifasta_index:
         sizes = f"{cdbg_dir}/contigs.sizes",
     output:
         f"{catlas_dir}_multifasta/multifasta.pickle",
-    params:
-        ksize = ksize,
     shell: """
         python -Werror -m spacegraphcats.search.index_cdbg_by_multifasta \
-             {cdbg_dir} {catlas_dir} {output} --query {input.queries} -k {params.ksize}
+             {cdbg_dir} {catlas_dir} {output} --query {input.queries} 
     """
 
 rule query_multifasta_by_signature:


### PR DESCRIPTION
This PR removes the argument ksize from `rule build_multifasta_index`, which uses the script `search.index_cdbg_by_multifasta.py`. In the script, ksize is inferred from the cdbg, not a user-specified argument

```
    ksize = kmer_idx.ksize
    notify(f"Using ksize {ksize} from k-mer index.")
    notify("loaded {} k-mers in index ({:.1f}s)",
           len(kmer_idx), time.time() - ki_start)
```

ready for review and merge after checks pass
