### PR TITLE
[MRG] Add chmod conditional for write access on bcalm.unitigs.db

### DIFF
--- a/spacegraphcats/conf/Snakefile
+++ b/spacegraphcats/conf/Snakefile
@@ -127,10 +127,6 @@ onsuccess:
                 print(f'search output directory: {search_dir}', file=sys.stderr)
             print('')
 
-# Add write permissions to bcalm.unitigs.db
-if os.path.exists(f'{cdbg_dir}/bcalm.unitigs.db'):
-    shell(f"chmod u+w {cdbg_dir}/bcalm.unitigs.db")
-
 ###############################################################################
 
 # print out the configuration
@@ -221,7 +217,7 @@ rule bcalm_catlas_prepare_input:
         gxt = f"{cdbg_dir}/cdbg.gxt",
         info = f"{cdbg_dir}/contigs.info.csv",
         sig = f"{cdbg_dir}/contigs.sig",
-        db = f"{cdbg_dir}/bcalm.unitigs.db",
+        db = protected(f"{cdbg_dir}/bcalm.unitigs.db"),
     shadow: "shallow"
     params:
         remove_pendants = "-P" if config.get('keep_graph_pendants', 0) else "",
@@ -232,7 +228,6 @@ rule bcalm_catlas_prepare_input:
             {input.db} {input.mapping} \
             {output.gxt} {params.contigs_prefix}
         mv {input.db} {output.db}
-        chmod u-w {output.db}
      """
 
 # output contigs file

--- a/spacegraphcats/conf/Snakefile
+++ b/spacegraphcats/conf/Snakefile
@@ -127,6 +127,9 @@ onsuccess:
                 print(f'search output directory: {search_dir}', file=sys.stderr)
             print('')
 
+# Add write permissions to bcalm.unitigs.db
+if os.path.exists(f'{cdbg_dir}/bcalm.unitigs.db'):
+    shell(f"chmod u+w {cdbg_dir}/bcalm.unitigs.db")
 
 ###############################################################################
 


### PR DESCRIPTION
**Please note** if this PR requires a rebuild of catlas or other big files. 
I don't think the above (^) is true.

Fixes #512 

Adding a python condition to check for bcalm.unitigs.db when the workflow begins. If the file exists it will be updated to provide the user with write access. After the final job is complete the file will no longer have user write access.