### PR TITLE
docs: fix logo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a collaboration between the
 Initial development of spacegraphcats was generously supported by the Moore Foundation's
 [Data Driven Discovery Initiative](https://www.moore.org/initiative-strategy-detail?initiativeId=data-driven-discovery).
 
-![spacegraphcats graph](https://github.com/spacegraphcats/spacegraphcats/raw/latest/pics/logo.png)
+![spacegraphcats graph](https://github.com/spacegraphcats/spacegraphcats/blob/main/pics/logo.png?raw=true)
 
 ## Documentation
 


### PR DESCRIPTION
Updated logo image link to use raw content URL.